### PR TITLE
fix(install): the one-command install exposed a shell it could not log into, and never restarted on re-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,19 @@ curl -fsSL https://raw.githubusercontent.com/rahmanef63/mso/main/scripts/install
 
 Run it as your normal server user, **not root**. The installer prints the first-login password once and explains how to approve your first browser device.
 
+It binds **`127.0.0.1` by default**, so nothing is published to your network. Reach it with an SSH tunnel and open `http://localhost:4005`:
+
+```bash
+ssh -N -L 4005:127.0.0.1:4005 you@your-server
+```
+
+That tunnel is not just hygiene. The session cookie is `Secure`, and browsers only keep a `Secure` cookie over plain http on `localhost` — so an `http://<ip>:4005` URL logs in successfully and then drops the cookie. For a permanent setup use `tailscale serve 4005` or a TLS reverse proxy pointed at `127.0.0.1:4005`; pass `--bind 0.0.0.0` only when a proxy you control is already in front.
+
 Useful options:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rahmanef63/mso/main/scripts/install.sh | bash -s -- --port 4005
+curl -fsSL https://raw.githubusercontent.com/rahmanef63/mso/main/scripts/install.sh | bash -s -- --bind 0.0.0.0
 curl -fsSL https://raw.githubusercontent.com/rahmanef63/mso/main/scripts/install.sh | bash -s -- --no-service
 curl -fsSL https://raw.githubusercontent.com/rahmanef63/mso/main/scripts/install.sh | bash -s -- --uninstall
 ```

--- a/app/install/page.tsx
+++ b/app/install/page.tsx
@@ -31,9 +31,10 @@ const STEPS = [
   },
   {
     n: 2,
-    title: "Put it behind something",
-    body: "MSO listens on :4005. An authenticated session can read allowed files and run commands as the process user, so treat the port like SSH: do not expose it raw to the internet. Tailscale or a VPN is the easy answer; a TLS reverse proxy with an allowlist also works.",
-    code: "sudo ufw deny 4005",
+    title: "Reach it",
+    body: "The installer binds 127.0.0.1, so :4005 is closed to every other machine and there is nothing to firewall. Tunnel in from whatever you browse on. The tunnel is not only for privacy: the session cookie is Secure, and a browser only keeps a Secure cookie over plain http on localhost — so an http://<ip>:4005 URL returns a successful login and then silently drops the cookie.",
+    code: "ssh -N -L 4005:127.0.0.1:4005 you@your-server",
+    note: "Then open http://localhost:4005. For something permanent use `tailscale serve 4005`, or a TLS reverse proxy on the server pointed at 127.0.0.1:4005 — both give the browser a trustworthy origin. Only pass --bind 0.0.0.0 if a proxy you control is already in front.",
   },
   {
     n: 3,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -110,8 +110,8 @@ User=youruser
 WorkingDirectory=/home/youruser/mso
 EnvironmentFile=/home/youruser/mso/.env.local
 Environment=PORT=4005
-Environment=HOSTNAME=0.0.0.0
-ExecStart=/usr/bin/npm run start -- --hostname 0.0.0.0 --port 4005
+Environment=HOSTNAME=127.0.0.1
+ExecStart=/usr/bin/npm run start -- --hostname 127.0.0.1 --port 4005
 Restart=always
 RestartSec=5
 MemoryMax=3G
@@ -156,8 +156,16 @@ fine for normal use, but interactive PTY sessions get cut mid-keystroke.
 ## 5. Put TLS in front (pick ONE)
 
 **Tailscale (recommended for a personal box):** don't expose anything.
-`tailscale up`, then reach `http://<machine>:4005` over the tailnet, or
-`tailscale serve 4005` for HTTPS. Firewall :4005 from the public net.
+`tailscale up`, then `tailscale serve 4005`, and browse the
+`https://<machine>.<tailnet>.ts.net` URL it prints.
+
+`tailscale serve` is required, not a nicer alternative: reaching
+`http://<machine>:4005` directly over the tailnet **cannot log in**. The session
+cookie is `Secure` (`lib/auth/session-cookie.ts`), and a browser only keeps a
+`Secure` cookie over plain http on `localhost` / `127.0.0.1` / `::1`. A
+`100.64.0.0/10` address or a MagicDNS name is neither, so the login returns 200
+and the cookie is dropped — an endless login loop with the right password. The
+same is true of every `http://<ip>:4005` URL.
 
 **Caddy (public domain):**
 
@@ -171,7 +179,10 @@ os.example.com {
 TLS (certbot). Keep `proxy_set_header Host $host;` and forward
 `X-Forwarded-For` (the login rate limiter keys on client IP).
 
-Either way: firewall :4005 (and :4002) so only the proxy / tailnet reaches them.
+Either way the app should stay on `127.0.0.1:4005` (the installer's default), so
+the proxy is the only thing that can reach it and there is no public port to
+firewall in the first place. If you deliberately bind wider with
+`--bind 0.0.0.0`, firewall :4005 as well.
 
 ## 6. Optional — the Browser app (Camoufox)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,6 +15,20 @@ DIR="${MSO_DIR:-$HOME/mso}"
 DIR_EXPLICIT=0
 REF="${MSO_REF:-main}"
 PORT="${MSO_PORT:-4005}"
+# Address the server listens on. Loopback by DEFAULT, for two reasons that point
+# the same way:
+#   1. It cannot log in otherwise. sessionCookieAttrs() sets `secure: true`
+#      (lib/auth/session-cookie.ts), and a browser only accepts a Secure cookie
+#      over plain http on a trustworthy origin — localhost / 127.0.0.1 / ::1. So
+#      http://<lan-or-public-ip>:PORT returns 200 on login and then silently
+#      drops the cookie: an endless login loop. A 0.0.0.0 bind buys no working
+#      access it did not already have.
+#   2. It is a shell. An authenticated session runs commands as this user, and a
+#      fresh VPS has ufw installed but disabled — so the old default published
+#      that shell to the whole internet about two minutes into a curl|bash.
+# Reach it over an SSH tunnel, `tailscale serve`, or a reverse proxy on this host
+# (all three land the browser on a trustworthy origin, so the cookie sticks).
+BIND="${MSO_BIND:-127.0.0.1}"
 SERVICE="mso.service"
 DO_SERVICE=1
 DO_UNINSTALL=0
@@ -38,10 +52,12 @@ mso installer
   --dir PATH     install dir (default: \$HOME/mso, or an existing service's dir)
   --ref REF      git ref/branch/tag to check out (default: main)
   --port N       listen port (default: 4005)
+  --bind ADDR    listen address (default: 127.0.0.1). 0.0.0.0 publishes a shell
+                 to every network this host is on — see the note in this file.
   --no-service   build only; skip the systemd unit
   --uninstall    stop+disable+remove the systemd unit (keeps code + ~/.mso)
   -h, --help     this help
-Env: MSO_DIR  MSO_REF  MSO_PORT  MSO_REPO
+Env: MSO_DIR  MSO_REF  MSO_PORT  MSO_BIND  MSO_REPO
 EOF
 }
 
@@ -50,6 +66,7 @@ while [ $# -gt 0 ]; do
     --dir)        DIR="$2"; DIR_EXPLICIT=1; shift 2 ;;
     --ref)        REF="$2"; shift 2 ;;
     --port)       PORT="$2"; shift 2 ;;
+    --bind)       BIND="$2"; shift 2 ;;
     --no-service) DO_SERVICE=0; shift ;;
     --uninstall)  DO_UNINSTALL=1; shift ;;
     -h|--help)    usage; exit 0 ;;
@@ -71,12 +88,32 @@ fi
 
 # ---- uninstall ----
 if [ "$DO_UNINSTALL" -eq 1 ]; then
-  if command -v systemctl >/dev/null 2>&1; then
+  # Guarded: without this, --uninstall on a box that never had the unit still
+  # asks for a sudo password and then claims to have removed something.
+  if command -v systemctl >/dev/null 2>&1 && [ -f "/etc/systemd/system/$SERVICE" ]; then
     sudo_do systemctl disable --now "$SERVICE" 2>/dev/null || true
     sudo_do rm -f "/etc/systemd/system/$SERVICE"
     sudo_do systemctl daemon-reload
     ok "removed $SERVICE"
+  else
+    info "no $SERVICE installed — nothing to remove"
   fi
+
+  # Take back the symlinks this script created. Both are resolved and compared
+  # against $DIR first, so a hand-made `mso` on PATH or a third-party skill of
+  # the same name is never touched.
+  UNINST_BIN="${MSO_BIN_DIR:-$HOME/.local/bin}/mso"
+  if [ -L "$UNINST_BIN" ] && case "$(readlink "$UNINST_BIN")" in "$DIR/"*) true ;; *) false ;; esac; then
+    rm -f "$UNINST_BIN"; ok "removed cli symlink $UNINST_BIN"
+  fi
+  UNINST_SKILLS="${MSO_SKILL_DIR:-$HOME/.claude/skills}"
+  if [ -d "$UNINST_SKILLS" ]; then
+    for l in "$UNINST_SKILLS"/*; do
+      [ -L "$l" ] || continue
+      case "$(readlink "$l")" in "$DIR/claude-skills/"*) rm -f "$l"; info "removed skill $(basename "$l")" ;; esac
+    done
+  fi
+
   info "code left at $DIR and data at ~/.mso — delete by hand if you want them gone."
   exit 0
 fi
@@ -211,8 +248,8 @@ User=$(id -un)
 WorkingDirectory=$DIR
 EnvironmentFile=$DIR/.env.local
 Environment=PORT=$PORT
-Environment=HOSTNAME=0.0.0.0
-ExecStart=$NPM_BIN run start -- --hostname 0.0.0.0 --port $PORT
+Environment=HOSTNAME=$BIND
+ExecStart=$NPM_BIN run start -- --hostname $BIND --port $PORT
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM
@@ -225,17 +262,50 @@ SyslogIdentifier=mso
 [Install]
 WantedBy=multi-user.target
 EOF
-  sudo_do systemctl daemon-reload
-  sudo_do systemctl enable --now "$SERVICE"
-  ok "$SERVICE enabled + started"
+  # A wildcard bind is not an address you can dial; probe loopback instead.
+  HEALTH_HOST="$BIND"
+  case "$BIND" in 0.0.0.0|::|"") HEALTH_HOST=127.0.0.1 ;; esac
 
-  info "waiting for http://127.0.0.1:$PORT/api/health …"
+  # Read the id of the build that is CURRENTLY answering, before we touch the
+  # unit. Every build gets a fresh NEXT_PUBLIC_BUILD_ID (next.config.mjs), so a
+  # changed id is what proves the new process took over.
+  prev_build="$(curl -fsS --max-time 3 "http://$HEALTH_HOST:$PORT/api/health" 2>/dev/null \
+                | sed -n 's/.*"buildId":"\([^"]*\)".*/\1/p' || true)"
+
+  sudo_do systemctl daemon-reload
+  sudo_do systemctl enable "$SERVICE"
+  # restart, NOT `enable --now`. `--now` only *starts*, and a start on a unit
+  # that is already running is a no-op — so re-running this installer used to
+  # fetch, rebuild and then leave the OLD process serving a .next that had been
+  # replaced underneath it. Every chunk 404s and nosniff makes that fatal
+  # (docs/TROUBLESHOOTING.md). `restart` starts an inactive unit just as well,
+  # so this is also correct on a first install.
+  sudo_do systemctl restart "$SERVICE"
+  ok "$SERVICE enabled + restarted"
+
+  info "waiting for http://$HEALTH_HOST:$PORT/api/health …"
   up=0
   for _ in $(seq 1 30); do
-    if curl -fsS --max-time 3 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1; then up=1; ok "health OK"; break; fi
+    body="$(curl -fsS --max-time 3 "http://$HEALTH_HOST:$PORT/api/health" 2>/dev/null || true)"
+    if [ -n "$body" ]; then
+      now_build="$(printf '%s' "$body" | sed -n 's/.*"buildId":"\([^"]*\)".*/\1/p')"
+      # Gate on the id, not on curl's exit status: the old process answers
+      # /api/health perfectly while serving stale chunks, which is exactly how
+      # a failed update used to report "health OK".
+      if [ -z "$prev_build" ] || [ "$now_build" != "$prev_build" ]; then
+        up=1; ok "health OK (build ${now_build:-unknown})"; break
+      fi
+    fi
     sleep 2
   done
-  [ "$up" -eq 1 ] || warn "no /api/health answer yet — check: journalctl -u mso -e"
+  if [ "$up" -ne 1 ]; then
+    # is-active needs no privileges — do not spend a sudo prompt on the sad path.
+    if systemctl is-active --quiet "$SERVICE"; then
+      warn "service is running but still serving build $prev_build — check: journalctl -u mso -e"
+    else
+      warn "$SERVICE is not running — check: journalctl -u mso -e"
+    fi
+  fi
 else
   [ "$DO_SERVICE" -eq 1 ] && warn "no systemctl here — skipping service. Run manually: PORT=$PORT bun run start"
 fi
@@ -277,10 +347,31 @@ if [ -d "$DIR/claude-skills" ] && [ -d "$(dirname "$SKILL_DIR")" ]; then
 fi
 
 # ---- next steps ----
+# How to reach it depends on the bind AND on the Secure session cookie: a
+# browser only keeps that cookie over plain http on localhost/127.0.0.1/::1, so
+# any address that is not one of those needs TLS or a tunnel to log in at all.
+WHOAMI="$(id -un)"
+case "$BIND" in
+  127.0.0.1|::1|localhost)
+    REACH="tunnel from your own machine:
+              ssh -N -L $PORT:127.0.0.1:$PORT $WHOAMI@<this-host>
+            then open  http://localhost:$PORT
+            (or \`tailscale serve $PORT\`, or a TLS reverse proxy → 127.0.0.1:$PORT)" ;;
+  0.0.0.0|::)
+    REACH="http://<this-host>:$PORT
+            !! bound on EVERY interface. An authenticated session runs commands as
+               $WHOAMI — firewall it, or re-run with --bind 127.0.0.1.
+               Plain http to an IP also cannot log in: the session cookie is Secure." ;;
+  *)
+    REACH="http://$BIND:$PORT
+            (plain http to a non-loopback address cannot complete a login — the
+             session cookie is Secure. Put TLS in front, or tunnel to loopback.)" ;;
+esac
+
 ok "mso installed at $DIR"
 cat <<EOF
 
-  Open:     http://<this-host>:$PORT     (put Tailscale/TLS in front — do NOT expose :$PORT raw)
+  Open:     $REACH
   Env:      $DIR/.env.local
 EOF
 [ -n "$GEN_PW" ] && printf '  Password: %s   (shown once — save it now; edit OS_LOGIN_PASSWORD in .env.local + restart to change)\n' "$GEN_PW"
@@ -295,5 +386,8 @@ cat <<EOF
 
   Logs:     journalctl -u mso -f
   Update:   re-run this installer (pull + rebuild + restart), or --uninstall to remove
-  Security: firewall :$PORT from the public net; review ~/.mso/audit.log
+  Listen:   $BIND:$PORT   (change with --bind / MSO_BIND)
+  Security: verify from OUTSIDE the box — \`curl -m5 http://<public-ip>:$PORT/api/health\`
+            run on your laptop is the only test that proves what is reachable.
+            Review ~/.mso/audit.log.
 EOF


### PR DESCRIPTION
## What this fixes

I ran the documented one-command install on a fresh Ubuntu 24.04 VPS and audited the result. Three things in `scripts/install.sh` and four in the docs do not do what they say.

### 1. The default bind published a shell it could not log into

The generated unit hardcoded `--hostname 0.0.0.0`, and a fresh VPS has ufw installed but `ENABLED=no`. So `curl … | bash` put a PTY that runs arbitrary commands as the installing user on the public internet about two minutes in, then printed the login password to the terminal. Nothing in the installer checks, touches, or verifies a firewall — while `README.md`, `SECURITY.md` and `docs/INSTALL.md` all say not to expose the raw port.

What makes this an easy call rather than a trade-off: **the exposure bought nothing.**

`sessionCookieAttrs()` sets `secure: true` (`lib/auth/session-cookie.ts:80`, asserted by `session-cookie.test.ts:93,106`). A browser only keeps a `Secure` cookie over plain http on a trustworthy origin — `localhost` / `127.0.0.1` / `::1`. So `http://<ip>:4005`, the exact URL the installer printed, returns `200 {success:true}` on login and then silently drops the cookie: an endless login loop with the correct password. The same applies to a tailnet `100.64.0.0/10` address.

So the old default was the worst available combination — open to the internet *and* unusable. Default is now `127.0.0.1`, with `--bind ADDR` / `MSO_BIND` to opt out.

The documented production topology is unaffected: Caddy and nginx already `reverse_proxy 127.0.0.1:4005`.

### 2. A re-run never restarted the service

`systemctl enable --now` only *starts*, and a start on an already-running unit is a no-op. So the documented update path — "re-run this installer (pull + rebuild + restart)" — fetched the new commit, reinstalled deps, and ran `bun run build` **inside the live service's WorkingDirectory**, replacing `.next` under the running process, then changed nothing about that process.

That is exactly the failure `docs/TROUBLESHOOTING.md:40-52` describes: `next start` still holds the old build manifest while `.next/static` on disk is new, every CSS/JS chunk 404s, and `X-Content-Type-Options: nosniff` makes it fatal.

`scripts/ship.sh:67` gets this right (`sudo -n systemctl restart mso.service`). The installer was the only path in the repo that omitted the restart, while being the documented update path for every user.

Now `enable` + `restart`. `restart` starts an inactive unit too, so it is also correct on a first install.

### 3. The health check reported success against the stale process

The loop only asserted that `curl` exited 0. `app/api/health/route.ts` imports nothing build-specific, so the **old** process answers it perfectly while serving a replaced `.next` — a broken update printed `✓ health OK` and then `✓ mso installed`.

It now reads `buildId` before touching the unit and waits for it to change. Every build gets a fresh `NEXT_PUBLIC_BUILD_ID` (`next.config.mjs`), so a changed id is what proves the new process took over. If it times out, the message now distinguishes "running but still serving the old build" from "not running".

### 4. Docs that pointed somewhere that cannot work

- `app/install/page.tsx` step 2 was `sudo ufw deny 4005`. On a fresh VPS ufw is inactive, so that adds a rule to a firewall that is not running and changes nothing — while the step tells the reader they have closed the port. It was the only command in the whole doc set claiming to close the exposure.
- `docs/INSTALL.md` §5 said Tailscale users could reach `http://<machine>:4005` over the tailnet. Same Secure-cookie problem — `tailscale serve` is required, not a nicer alternative.
- §4's unit block still showed the `0.0.0.0` bind.
- Dropped `(and :4002)` from the firewall advice; that sidecar was deleted on 2026-08-10 per the same file.

### 5. `--uninstall` left its own symlinks behind

It never removed `~/.local/bin/mso` or the `~/.claude/skills/*` symlinks, so following it left a broken `mso` on `PATH` and dangling skill entries the agent still lists. Both are now resolved and compared against `$DIR` first, so a hand-made `mso` or a third-party skill of the same name is never touched. It also no longer spends a sudo prompt claiming to remove a unit that was never installed.

## Verification

Run against this branch with the repo's own gates:

| gate | result |
|---|---|
| `bun run typecheck` | pass |
| `bun run lint` | pass |
| `bun run test` | 1246 passed, 1 expected fail, 7 skipped |
| `bun run check` | 0 cycles, 0 contrast failures |
| `bun run audit` | **fails** on a pre-existing `nanoid` advisory (GHSA-2v37-7h3g-55p8), unrelated to this change and untouched here |

I also ran a live A/B on the box: a second instance started with `--hostname 127.0.0.1` on a spare port, compared against the running `0.0.0.0` service. Identical status codes on every reachable route, including `/api/v1/managed-apps/{hermes,openclaw}/proxy*` (401/308 both).

## One thing I could not verify, and a comment worth a second look

`proxy.ts:206-209` says:

> `next start --hostname 0.0.0.0` (how the unit starts it) agrees with itself here; `--hostname 127.0.0.1` does NOT, and every rewrite 500s under it.

That comment is the reason I initially assumed a loopback default was impossible, so it matters for this PR.

The split-origin middleware rewrite it describes needs `NEXT_PUBLIC_MANAGED_APP_HOST_TEMPLATE`, which is build-time and unset in my build — so **I could not exercise that specific path**, and I have not changed the comment.

Reading `next@16.2.7` suggests it may be over-stated: `attachRequestMeta()` builds `initUrl` from the `--hostname` value, `resolve-routes.js` relativizes the rewrite against that same `initUrl` by pure origin equality, and `proxy.ts:213` builds the destination as `new URL(path, request.nextUrl.origin)` — the same origin by construction, for any bind host. If that reading is right, the constraint is "the base must be `nextUrl.origin`", not "the bind must be `0.0.0.0`".

You wrote that comment from experience I do not have, so I would rather you judge it than have me quietly edit it. If it is accurate for split-origin deployments, the right follow-up is probably to keep the loopback default (nobody doing a fresh `curl | bash` has Hermes or OpenClaw yet) and document `--bind <the-address-your-browser-uses>` for managed-app users.

## Scope note

Commit 1 bundles the bind default with the restart fix because they share the health-check code. If the bind change needs discussion, the restart and health-check hunks stand alone and I am happy to split them into a separate PR so that fix can land immediately — it silently breaks every documented update today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCPor4P4FBh8qe9jGNndSR
