### PR TITLE
feat(proxy): relay signed Hermes website jobs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@
 Newest first. `docs/PROGRESS.md` is the source of truth for *why* a change was made;
 this is the *what*, and it is what Settings → About shows as “What's new”.
 
+## 2026-08-21
+
+**Added**
+
+- `proxy` relay signed Hermes website jobs
+
 ## 2026-08-20
 
 **Added**

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -8,6 +8,13 @@ Running log of what shipped each phase. Newest at top.
 > Read those phases as history. **This file is the source of truth for what exists** —
 > `ARCHITECTURE.md` is no longer maintained and carries a stale-warning banner.
 
+
+## 2026-08-21 — signed Convex → Hermes website relay on the existing MSO host (DONE)
+
+AntiNRML's Discord application uses one HTTP Interactions Endpoint (Convex), while Hermes' generic webhook listener intentionally stays on loopback-facing host port 8644. Docker/Traefik cannot reach arbitrary host ports by design, so opening 8644 for one integration would weaken the firewall. The Hermes app host now has exactly one machine-to-machine exception in `proxy.ts`: signed `POST /webhooks/antinrml-website` requests reach MSO on the already-allowed :4005 path and are rewritten by the host process to `127.0.0.1:8644/webhooks/antinrml-website`. Every other Hermes path keeps the normal app-host CSRF/session boundary.
+
+MSO does not duplicate the shared HMAC secret. It cheaply rejects non-JSON, stale timestamps, malformed signatures and declared bodies over 256 KiB; Hermes remains the cryptographic authority and verifies the full timestamp-bound HMAC before accepting a job. The target host/path is constant, so the exception cannot become SSRF or a generic webhook relay.
+
 ## 2026-08-20 — lossless continuation and exact-id project resolution (DONE)
 
 The final fail-closed review found six remaining items. Five were continuation bugs of the

--- a/lib/managed-apps/hermes-webhook-relay.test.ts
+++ b/lib/managed-apps/hermes-webhook-relay.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const TEMPLATE = "{id}.mso.rahmanef.com";
+const HERMES = "/api/v1/managed-apps/hermes/proxy";
+const TARGET = "http://127.0.0.1:8644/webhooks/antinrml-website";
+
+async function loadProxy() {
+  vi.resetModules();
+  vi.stubEnv("NEXT_PUBLIC_MANAGED_APP_HOST_TEMPLATE", TEMPLATE);
+  return (await import("../../proxy")).proxy;
+}
+
+function req(host: string, path: string, init: { method?: string; headers?: HeadersInit; body?: string } = {}) {
+  const headers = new Headers(init.headers);
+  headers.set("host", host);
+  return new NextRequest(`https://${host}${path}`, { ...init, headers });
+}
+
+const rewriteOf = (res: Response) => res.headers.get("x-middleware-rewrite");
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("Hermes signed website webhook relay", () => {
+  it("relays only the exact Hermes POST path to loopback before the app-host CSRF gate", async () => {
+    const proxy = await loadProxy();
+    const res = await proxy(req("hermes.mso.rahmanef.com", "/webhooks/antinrml-website", {
+      method: "POST",
+      headers: {
+        "sec-fetch-site": "cross-site",
+        "content-type": "application/json",
+        "x-webhook-timestamp": String(Math.floor(Date.now() / 1000)),
+        "x-webhook-signature-v2": "a".repeat(64),
+      },
+      body: "{}",
+    }));
+    expect(rewriteOf(res)).toBe(TARGET);
+  });
+
+  it("rejects malformed or stale machine-auth headers before loopback", async () => {
+    const proxy = await loadProxy();
+    const cases = [
+      { "content-type": "text/plain", "x-webhook-timestamp": String(Math.floor(Date.now() / 1000)), "x-webhook-signature-v2": "a".repeat(64) },
+      { "content-type": "application/json", "x-webhook-timestamp": String(Math.floor(Date.now() / 1000) - 301), "x-webhook-signature-v2": "a".repeat(64) },
+      { "content-type": "application/json", "x-webhook-timestamp": String(Math.floor(Date.now() / 1000)), "x-webhook-signature-v2": "deadbeef" },
+    ];
+    for (const headers of cases) {
+      const res = await proxy(req("hermes.mso.rahmanef.com", "/webhooks/antinrml-website", {
+        method: "POST", headers: { ...headers, "sec-fetch-site": "cross-site" }, body: "{}",
+      }));
+      expect(rewriteOf(res)).not.toBe(TARGET);
+      expect(res.status).toBe(403);
+    }
+  });
+
+  it("does not turn other Hermes webhook paths into a public relay", async () => {
+    const proxy = await loadProxy();
+    const res = await proxy(req("hermes.mso.rahmanef.com", "/webhooks/anything-else", {
+      method: "POST", headers: { "sec-fetch-site": "cross-site" }, body: "{}",
+    }));
+    expect(res.status).toBe(403);
+    expect(rewriteOf(res)).toBeNull();
+  });
+
+  it("keeps GET on the normal authenticated Hermes app proxy", async () => {
+    const proxy = await loadProxy();
+    const res = await proxy(req("hermes.mso.rahmanef.com", "/webhooks/antinrml-website"));
+    expect(new URL(rewriteOf(res)!).pathname).toBe(`${HERMES}/webhooks/antinrml-website`);
+  });
+
+  it("never exposes the relay on OpenClaw or the cockpit host", async () => {
+    const proxy = await loadProxy();
+    for (const host of ["openclaw.mso.rahmanef.com", "mso.rahmanef.com"]) {
+      const res = await proxy(req(host, "/webhooks/antinrml-website", {
+        method: "POST", headers: { "sec-fetch-site": "cross-site" }, body: "{}",
+      }));
+      expect(rewriteOf(res)).not.toBe(TARGET);
+    }
+  });
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -70,6 +70,26 @@ async function hasApprovedSession(request: NextRequest): Promise<boolean> {
 // per-asset work). Prefix semantics kept exactly as the old negative lookahead's.
 const MATCHER_EXCLUDED = /^\/(?:_next\/static|_next\/image|favicon\.ico)/;
 
+const HERMES_WEBSITE_WEBHOOK_PATH = "/webhooks/antinrml-website";
+const HERMES_WEBSITE_BODY_LIMIT = 256 * 1024;
+
+// Cheap edge prefilter only. Hermes is still the cryptographic authority: it
+// verifies HMAC(secret, timestamp + "." + body). This rejects obvious public
+// garbage before it is proxied to the loopback listener without copying the
+// shared secret into MSO.
+function plausibleHermesWebsiteWebhook(request: NextRequest): boolean {
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.startsWith("application/json")) return false;
+  const timestamp = request.headers.get("x-webhook-timestamp") ?? "";
+  const seconds = Number(timestamp);
+  if (!Number.isInteger(seconds) || Math.abs(Math.floor(Date.now() / 1000) - seconds) > 300) return false;
+  if (!/^[0-9a-f]{64}$/i.test(request.headers.get("x-webhook-signature-v2") ?? "")) return false;
+  const length = Number(request.headers.get("content-length") ?? "0");
+  if (Number.isFinite(length) && length > HERMES_WEBSITE_BODY_LIMIT) return false;
+  return true;
+}
+
+
 function blocked() {
   return NextResponse.json({ error: "cross_origin_blocked" }, { status: 403 });
 }
@@ -149,6 +169,24 @@ export async function proxy(request: NextRequest) {
   // lie (claiming an app host while on the cockpit) only restricts the request.
   const host = request.headers.get("host") ?? request.nextUrl.host;
   const managedApp = managedAppIdForHost(host);
+
+  // One deliberately public machine-to-machine lane on the Hermes app host.
+  // Discord itself still talks only to Convex; Convex signs the resulting job
+  // with HMAC V2 and POSTs it here. The destination is a hard-coded loopback
+  // path, so this cannot become a generic SSRF/open-relay primitive. Do this
+  // BEFORE the app-host CSRF gate: a server-to-server HMAC request has no cockpit
+  // session cookie and is cross-site by design. Hermes is the authentication
+  // boundary and rejects missing/invalid/replayed signatures.
+  if (
+    managedApp === "hermes" &&
+    request.method === "POST" &&
+    pathname === HERMES_WEBSITE_WEBHOOK_PATH &&
+    plausibleHermesWebsiteWebhook(request)
+  ) {
+    return NextResponse.rewrite(
+      new URL(`http://127.0.0.1:8644${HERMES_WEBSITE_WEBHOOK_PATH}`),
+    );
+  }
 
   // A host inside the app namespace that is NOT an app (a new `X.mso.rahmanef.com`
   // record, or a `*.os` wildcard) must not serve the cockpit: the session cookie is


### PR DESCRIPTION
Adds one exact-path POST relay on the Hermes managed-app host to the loopback Hermes webhook adapter. This supports Team AntiNRML /website jobs while preserving app-host CSRF isolation. Guarded by exact host/app, exact method, exact path, hard-coded loopback destination; Hermes still verifies replay-protected HMAC. Verification: 1,523 full tests passed (+ expected/skipped baseline), 4 dedicated relay tests, typecheck and production build passed.