### PR TITLE
feat(projects): add opt-in MCP and function capabilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -217,3 +217,9 @@ OS_SESSION_SECRET=
 # Internal loopback origin used by the read-only `screen_capture` MCP tool. The
 # implementation refuses non-loopback values. Default http://127.0.0.1:4005.
 # OS_SCREENSHOT_ORIGIN=http://127.0.0.1:4005
+
+# Optional exact machine-to-machine ingress for PROJECT integrations on a managed
+# app host. Stock MSO leaves this unset and exposes no such lane. JSON array, max
+# 8 entries; POST only; target MUST be loopback; auth currently hmac-v2-json.
+# MSO only prefilters HMAC-shaped headers — the loopback app verifies the secret.
+# OS_PROJECT_INGRESS_ROUTES=[{"app":"hermes","method":"POST","path":"/webhooks/project-example","target":"http://127.0.0.1:8644/webhooks/project-example","auth":"hmac-v2-json","maxBodyBytes":262144}]

--- a/app/globals.css
+++ b/app/globals.css
@@ -524,10 +524,11 @@ body {
    the jump moves (maximize/un-maximize/snap) animate. */
 .win-geo { transition: left var(--shell-dur) var(--shell-ease), top var(--shell-dur) var(--shell-ease), width var(--shell-dur) var(--shell-ease), height var(--shell-dur) var(--shell-ease); }
 
-@keyframes appOpen { from { transform: translateY(14px) scale(0.985); } to { transform: none; } }
-/* Dismiss-to-home: the app zooms down a touch + fades, revealing the home
-   behind it (real-iOS close). Finalized on animationend in mobile-shell. */
-@keyframes appClose { from { transform: none; opacity: 1; } to { transform: translateY(10px) scale(0.96); opacity: 0; } }
+/* Mobile app transitions intentionally do NOT scale/zoom the whole UI. On phones
+   a full-surface scale makes text and controls visibly breathe; a short spatial
+   translate keeps orientation/navigation feedback without changing perceived UI size. */
+@keyframes mobileAppOpen { from { transform: translateY(10px); } to { transform: none; } }
+@keyframes mobileAppClose { from { transform: none; opacity: 1; } to { transform: translateY(8px); opacity: 0; } }
 /* Live-wallpaper blob drift (transform-only — compositor-friendly). */
 @keyframes wpFloatA { 0%, 100% { transform: translate(-10%, -6%) scale(1); } 50% { transform: translate(12%, 8%) scale(1.18); } }
 @keyframes wpFloatB { 0%, 100% { transform: translate(8%, 10%) scale(1.1); } 50% { transform: translate(-10%, -8%) scale(0.92); } }

--- a/app/globals.css
+++ b/app/globals.css
@@ -303,9 +303,9 @@ body {
   border-radius: var(--shell-icon-radius);
 }
 
-/* Platform-specific generated app artwork. Only the active desktop shell's
-   image is painted; other shells keep the generic fallback. This keeps one app
-   identity while letting macOS and Windows use genuinely different icon art. */
+/* Platform-family app artwork. Apple surfaces share the macOS artwork family
+   (macOS + iOS), while Microsoft/Material surfaces share the Windows artwork
+   family (Windows + Android). Dashboard keeps the generic fallback. */
 .shell-artwork {
   position: absolute;
   inset: 0;
@@ -318,9 +318,13 @@ body {
 }
 .shell-artwork-macos, .shell-artwork-windows { display: none; }
 [data-shell="macos"] .shell-artwork-default,
-[data-shell="windows"] .shell-artwork-default { display: none; }
-[data-shell="macos"] .shell-artwork-macos { display: block; }
-[data-shell="windows"] .shell-artwork-windows { display: block; }
+[data-shell="ios"] .shell-artwork-default,
+[data-shell="windows"] .shell-artwork-default,
+[data-shell="android"] .shell-artwork-default { display: none; }
+[data-shell="macos"] .shell-artwork-macos,
+[data-shell="ios"] .shell-artwork-macos { display: block; }
+[data-shell="windows"] .shell-artwork-windows,
+[data-shell="android"] .shell-artwork-windows { display: block; }
 
 /* ── iOS component parity (scoped to the iOS surface ONLY) ─────────────────
    Shared primitives (Switch, Segmented) carry accent-tinted states that suit

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `icons` align mobile platform artwork
 - `responsive` harden mobile and landscape layouts
 - `git` isolate push-gate test repositories
 - `settings` improve MCP UI and activity scrolling

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@
 Newest first. `docs/PROGRESS.md` is the source of truth for *why* a change was made;
 this is the *what*, and it is what Settings → About shows as “What's new”.
 
+## 2026-08-21
+
+**Added**
+
+- `projects` add opt-in function capabilities
+
 ## 2026-08-20
 
 **Added**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `git` isolate push-gate test repositories
 - `settings` improve MCP UI and activity scrolling
 
 ## 2026-08-21

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@
 Newest first. `docs/PROGRESS.md` is the source of truth for *why* a change was made;
 this is the *what*, and it is what Settings → About shows as “What's new”.
 
+## 2026-08-22
+
+**Fixed**
+
+- `settings` improve MCP UI and activity scrolling
+
 ## 2026-08-21
 
 **Added**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `responsive` harden mobile and landscape layouts
 - `git` isolate push-gate test repositories
 - `settings` improve MCP UI and activity scrolling
 

--- a/docs/CONNECTORS-GATEWAY-INTEGRATION.md
+++ b/docs/CONNECTORS-GATEWAY-INTEGRATION.md
@@ -4,7 +4,7 @@
 
 ## Cross-repo contract
 
-MSO currently exposes **26 tool names** (server `1.5.3`, toolset `2026.08.20.6`). The gateway manifest still maps **15** of them through literal `x-upstream` strings:
+MSO currently exposes **28 tool names** (server `1.6.0`, toolset `2026.08.21.1`). The gateway manifest still maps **15** of them through literal `x-upstream` strings:
 
 ```json
 { "id": "mso.fs.delete", "x-upstream": "fs_delete" }
@@ -38,6 +38,8 @@ The gateway has not yet synchronized the tools added or deliberately withheld fr
 | `workflow_finish` | added later; exact-id verified recipe boundary |
 | `fs_upload_file` | added later; ChatGPT `openai/fileParams` binding the gateway does not model |
 | `projects_list` | added 2026-08-20; enumerates every configured project container |
+| `project_capabilities` | added 2026-08-21; detects opt-in project MCP/function manifests without exposing secrets |
+| `project_function_call` | added 2026-08-21; exec-scope generic runner for functions declared by a project |
 | `skills_list` | added 2026-08-20; global + per-project skill catalog with trust |
 | `skills_read` | added 2026-08-20; exact-catalog-id SKILL.md read, trusted tiers only |
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -59,14 +59,14 @@ Picked per token, on the consent screen, capped by `OS_MCP_MAX_SCOPE`. The highe
 
 | Scope | Tools |
 |---|---|
-| `read` | `fs_list` `fs_read` `fs_search` `fs_usage` `sys_stats` `sys_processes` `apps_list` `apps_logs` `projects_list` `skills_list` `skills_read` `skills_search` `screen_capture` `browser_status` |
+| `read` | `fs_list` `fs_read` `fs_search` `fs_usage` `sys_stats` `sys_processes` `apps_list` `apps_logs` `projects_list` `project_capabilities` `skills_list` `skills_read` `skills_search` `screen_capture` `browser_status` |
 | `write` | + `workflow_start` `workflow_cancel` `workflow_finish` `fs_write` `fs_upload_file` `fs_mkdir` `fs_move` `fs_copy` `fs_delete` `apps_power` |
-| `exec` | + `exec_run` `browser_power` |
+| `exec` | + `project_function_call` `exec_run` `browser_power` |
 
 Alfa — the in-app assistant — has the same host capabilities under dot.case names,
 and `lib/mcp/parity.test.ts` fails if one surface gains a tool the other lacks
 without a written reason. `skills_search` maps to Alfa's `skills.search`.
-`screen_capture`, `projects_list`, `fs_upload_file`, `workflow_start`, `workflow_cancel` and
+`screen_capture`, `projects_list`, `project_capabilities`, `project_function_call`, `fs_upload_file`, `workflow_start`, `workflow_cancel` and
 `workflow_finish` are explicitly MCP-only: the external connector needs visual proof,
 an explicit project enumeration and an actor-scoped task boundary, while Alfa already
 runs inside the rendered shell, has the Files window and owns an in-app run boundary.
@@ -104,10 +104,58 @@ The catalog has a stable server version plus a schema-derived toolset signature.
 
 Settings → MCP shows the current version/hash/count and stores a browser-local acknowledgement when the operator marks ChatGPT refreshed. A later signature change becomes an explicit stale-snapshot warning. This does not mutate ChatGPT remotely; it makes the required refresh visible instead of relying on memory.
 
-Current catalog: **26 tools** (14 read, 10 write, 2 exec), server `1.5.3` / toolset
-`2026.08.20.6`. `projects_list`, `skills_list` and `skills_read` are the new public
-names in this release; `image_generation_status` and `image_generate` were removed
-(see the migration note below).
+Current catalog: **28 tools** (15 read, 10 write, 3 exec), server `1.6.0` / toolset
+`2026.08.21.1`. `project_capabilities` and `project_function_call` add one stable
+project-automation seam without creating a dynamic MCP tool catalog; existing tool names
+remain unchanged.
+
+## Opt-in project MCP/function capabilities
+
+MSO itself stays generic. A project opts into extra automation by placing files inside
+its own validated project directory:
+
+- `.mcp.json` — MSO reports only that the MCP config exists. It never returns the file
+  contents because MCP configs commonly contain env/credential wiring. MSO does not
+  automatically connect to arbitrary project MCP servers.
+- `.mso/functions.json` — a bounded manifest of project-owned functions.
+
+The manifest is versioned and intentionally uses **fixed argv**, not a shell template:
+
+```json
+{
+  "version": 1,
+  "functions": [{
+    "name": "asset_status",
+    "description": "Read the project's asset status.",
+    "inputSchema": {
+      "type": "object",
+      "properties": { "id": { "type": "string" } },
+      "required": ["id"],
+      "additionalProperties": false
+    },
+    "command": ["bun", "run", "project:call", "--", "asset_status"]
+  }]
+}
+```
+
+`project_capabilities` is read-scope and returns only public name/description/schema
+metadata. `project_function_call` is always **exec-scope**, even for a function named
+"read": it executes project code. MSO spawns the manifest argv directly with no shell
+and sends the model/caller's JSON object on stdin; caller values are never interpolated
+into command arguments. The child receives the existing scrubbed environment, so MSO
+credentials and provider tokens are not inherited. Projects without either file gain no
+new behavior.
+
+This shape preserves the global-tool invariant: MCP clients always see the same two MSO
+tool names, while the project-specific function names are data returned after project
+resolution. It also means adding a function to a project does not change MSO's toolset
+hash or force a cold prompt-cache prefix.
+
+For project callbacks that must enter a managed app (for example a signed webhook into a
+loopback-only agent), deployments may opt into `OS_PROJECT_INGRESS_ROUTES`. It defaults
+to empty. Routes are exact POST paths, max eight, loopback-only targets, and currently
+require HMAC-V2-shaped JSON headers; the loopback service remains responsible for real
+cryptographic verification.
 
 ## Safe text inspection and overwrite
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -8,6 +8,28 @@ Running log of what shipped each phase. Newest at top.
 > Read those phases as history. **This file is the source of truth for what exists** —
 > `ARCHITECTURE.md` is no longer maintained and carries a stale-warning banner.
 
+## 2026-08-21 — opt-in project MCP/function capabilities; stock MSO unchanged (DONE)
+
+Project-specific automation no longer requires a business-specific feature in MSO. A
+validated project may opt in with `.mcp.json` (presence only; contents/credentials are
+never exposed) and `.mso/functions.json` (versioned public schemas + fixed argv). The
+public MCP catalog stays stable: `project_capabilities` discovers one project's declared
+surface and `project_function_call` executes one declared function at **exec** scope.
+Function names are data, not dynamic MCP tool names, so switching projects does not alter
+the model tool prefix or invalidate the prompt cache. Caller input is JSON stdin to
+`spawn(argv)` — never shell interpolation — and child processes inherit the existing
+credential-scrubbed environment. No manifest means no extra capability.
+
+The same opt-in rule now applies to public machine ingress.
+`OS_PROJECT_INGRESS_ROUTES` defaults to empty; when explicitly configured it permits at
+most eight exact POST paths on known managed-app hosts, targets loopback HTTP only, and
+requires HMAC-V2-shaped JSON traffic before the app-host CSRF gate. The loopback app still
+verifies the real secret. There is no project/product name or webhook path compiled into
+MSO. Tests pin both sides: stock MSO remains closed, malformed/off-box/wildcard routes fail
+closed, `.mso` symlinks are ignored, project commands cannot interpolate caller strings
+into a shell, and project function execution remains exec-only. Toolset advances to
+`1.6.0` / `2026.08.21.1`: **28 tools** (15 read, 10 write, 3 exec).
+
 ## 2026-08-20 — lossless continuation and exact-id project resolution (DONE)
 
 The final fail-closed review found six remaining items. Five were continuation bugs of the

--- a/frontend/slices/appshell/components/mobile-notifications.tsx
+++ b/frontend/slices/appshell/components/mobile-notifications.tsx
@@ -40,7 +40,7 @@ export function MobileNotifications({ open, onClose }: { open: boolean; onClose:
   if (!open) return null;
 
   return (
-    <div className="glass absolute inset-0 z-[40] flex flex-col [animation:appOpen_var(--shell-dur)_var(--shell-ease)]" style={{ background: "var(--glass-nc)" }}>
+    <div className="glass absolute inset-0 z-[40] flex flex-col [animation:mobileAppOpen_var(--shell-dur)_var(--shell-ease)]" style={{ background: "var(--glass-nc)" }}>
       <header className="flex items-center px-5 pb-2 pt-10 text-white">
         <h2 className="text-[22px] font-bold">Notifications</h2>
         {items.length > 0 && (

--- a/frontend/slices/appshell/components/mobile-shell.tsx
+++ b/frontend/slices/appshell/components/mobile-shell.tsx
@@ -30,7 +30,7 @@ export function MobileShell() {
   const [cc, setCc] = useState(false);
   const [nc, setNc] = useState(false); // notification center (pull down, left half)
   const [appScrolled, setAppScrolled] = useState(false); // iOS nav-bar frost-on-scroll
-  const [closing, setClosing] = useState(false); // playing the dismiss-to-home zoom
+  const [closing, setClosing] = useState(false); // playing the dismiss-to-home slide
   const [actionsOpen, setActionsOpen] = useState(false); // in-app "•••" action drawer
 
   // Dock = manifest-pinned apps (AppDescriptor.pinned — the generic shell never
@@ -91,7 +91,7 @@ export function MobileShell() {
   };
   const goHome = () => {
     setSwitcher(false);
-    // Zoom the app down to the home (real-iOS dismiss) when it's actually
+    // Slide the app down to the home when it's actually
     // front-most and we're not coming from the switcher; the app layer's
     // onAnimationEnd finalises (minimise + show home). Otherwise go straight home.
     if (topId && !home && !switcher) {
@@ -100,7 +100,7 @@ export function MobileShell() {
     }
     setHome(true);
   };
-  // Called by the app layer once the dismiss zoom finishes.
+  // Called by the app layer once the dismiss transition finishes.
   const finishClose = () => {
     if (topId) minimizeWindow(topId);
     setClosing(false);
@@ -163,7 +163,7 @@ export function MobileShell() {
       <div className="absolute inset-0 z-[10] flex flex-col">
       {/* Home is inert while an app covers it (a11y: its grid, pager pages and
           home-indicator otherwise stay in tab/AT order under the opaque app
-          layer). It stays visually mounted for the appOpen zoom. */}
+          layer). It stays visually mounted behind the app transition. */}
       <MobileHome
         apps={apps}
         dockApps={dockApps}
@@ -180,11 +180,11 @@ export function MobileShell() {
         <div
           className={cn(
             "absolute inset-0 z-[10] flex flex-col [transform-origin:center_bottom]",
-            closing && "pointer-events-none", // lock interaction during the dismiss zoom
+            closing && "pointer-events-none", // lock interaction during the dismiss transition
           )}
           style={{
             background: "var(--surface)",
-            animation: `${closing ? "appClose" : "appOpen"} var(--shell-dur-slow) var(--shell-ease)`,
+            animation: `${closing ? "mobileAppClose" : "mobileAppOpen"} var(--shell-dur-slow) var(--shell-ease)`,
           }}
           // Finalise the dismiss only when the APP layer's OWN close animation
           // ends (guard against a child animation bubbling up).
@@ -249,7 +249,7 @@ export function MobileShell() {
               floor still applies, so nothing regresses where the sum used to be right. */}
           <main
             onScrollCapture={(e) => setAppScrolled((e.target as HTMLElement).scrollTop > 4)}
-            className="relative min-h-0 flex-1 overflow-auto [container-type:inline-size]"
+            className="relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto [container-type:inline-size]"
             style={{ "--sai-bottom": "max(env(safe-area-inset-bottom, 0px), 34px)" } as React.CSSProperties}
           >
             <WindowContent app={top.app} payload={top.payload} />

--- a/frontend/slices/appshell/components/shells/android/android-notifications.tsx
+++ b/frontend/slices/appshell/components/shells/android/android-notifications.tsx
@@ -45,7 +45,7 @@ export function AndroidNotifications({ open, onClose }: { open: boolean; onClose
     // It had no animation at all before; the black wash appeared in one frame.
     <div className="absolute inset-0 z-[45] flex flex-col bg-black/40 animate-in fade-in duration-[var(--m3-dur-effects)] ease-[var(--m3-effects)]" onClick={onClose}>
       {/* The shade is pulled DOWN from the top edge, but it was animating with
-          `appOpen`, which travels 14px UPWARD from below — the panel arrived moving
+          the old app-open transition, which traveled UPWARD from below — the panel arrived moving
           against the gesture that summoned it. It now slides down from -100% (its
           own height, above the viewport) on the M3 SPATIAL SLOW spring (k=200,
           ζ=0.8, ~511ms): a full-width surface, so the slow tier.

--- a/frontend/slices/appshell/components/shells/android/android-parts.tsx
+++ b/frontend/slices/appshell/components/shells/android/android-parts.tsx
@@ -163,13 +163,13 @@ export function AppDrawer({ apps, onLaunch, onClose }: { apps: AppDescriptor[]; 
   return (
     // Spatial SLOW (k=200, ζ=0.8, ~511ms): M3 picks the speed tier from the SIZE of
     // the moving element, and this is a full-screen surface. Only the model changed
-    // here — a 300ms cubic-bezier for the sampled spring — because appOpen's 14px
-    // UPWARD travel was already the right direction: the drawer is opened from the
+    // here — a sampled spring on mobileAppOpen's small UPWARD travel, which is
+    // already the right direction: the drawer is opened from the
     // "All apps" target at the BOTTOM of the home surface, so it should arrive
     // rising from where the finger was. (That target is drawn as a grabber but is a
     // plain tap — there is no swipe-up gesture in this shell, only usePullDown for
     // the shade and useSwipeUpClose for Recents cards.)
-    <div className="absolute inset-0 z-[30] flex flex-col bg-background/95 backdrop-blur-xl [animation:appOpen_var(--m3-dur-spatial-slow)_var(--m3-spatial)]">
+    <div className="absolute inset-0 z-[30] flex flex-col bg-background/95 backdrop-blur-xl [animation:mobileAppOpen_var(--m3-dur-spatial-slow)_var(--m3-spatial)]">
       {/* Visually a thin pull handle, but a ≥36px hit area (same treatment as
           the iOS home indicator) so it's actually closable by thumb. */}
       <Button

--- a/frontend/slices/appshell/components/shells/android/android-shell.tsx
+++ b/frontend/slices/appshell/components/shells/android/android-shell.tsx
@@ -13,7 +13,7 @@
 import { Button } from "@/components/ui/button";
 import { useCallback, useMemo, useRef, useState, type CSSProperties } from "react";
 import { useUrlHome } from "../../../hooks/use-url-home";
-import { Search, ArrowLeft, MoreHorizontal, Sparkles } from "lucide-react";
+import { Search, MoreHorizontal, Sparkles } from "lucide-react";
 import { useApps } from "../../../lib/registry";
 import { usePullDown } from "../../../hooks/use-pull-down";
 import { useWindowOrder, useFocused, useWindow } from "../../../hooks/use-shell";
@@ -178,16 +178,16 @@ function AndroidShell() {
         {/* Fullscreen app. Open = M3 SPATIAL SLOW (k=200, ζ=0.8, ~511ms). The speed
             tier is chosen by the SIZE of the thing that moves, not by how far it
             moves: this is the largest surface in the shell, so "slow" is right even
-            though appOpen only travels 14px. Most of the perceived movement is over
+            though mobileAppOpen only travels 10px. Most of the perceived movement is over
             by ~40% of that; the tail is the settle, which is exactly the part a
             cubic-bezier cannot express. Transform-only on purpose — no opacity,
             because pairing an effects fade with a spatial slide inside ONE animation
             would force a single easing on both families. */}
         {showApp && activeApp && top && (
-          <div className="absolute inset-0 z-[20] flex flex-col bg-background [animation:appOpen_var(--m3-dur-spatial-slow)_var(--m3-spatial)] [transform-origin:center_bottom]">
-            {/* M3 top app bar: flat surface (bg-card, hairline divider), leading
-                ArrowLeft up-affordance, Title Large regular weight — not a colored
-                brand header. The per-app color still reads on the icon + recents. */}
+          <div className="absolute inset-0 z-[20] flex flex-col bg-background [animation:mobileAppOpen_var(--m3-dur-spatial-slow)_var(--m3-spatial)] [transform-origin:center_bottom]">
+            {/* M3 top app bar: flat surface (bg-card, hairline divider), Title Large
+                regular weight — not a colored brand header. System Back stays in
+                the navigation row below, so this bar does not duplicate it. The per-app color still reads on the icon + recents. */}
             <header
               className="flex shrink-0 items-center gap-3 border-b border-border bg-card px-3 text-foreground"
               style={{ height: "calc(3rem + var(--sai-top, 0px))", paddingTop: "var(--sai-top, 0px)" }}
@@ -196,8 +196,11 @@ function AndroidShell() {
                   small elements, so "fast" (k=800, ζ=0.6, ~322ms, 9.3% overshoot).
                   The overshoot is what makes a press feel like a physical button
                   releasing rather than a scale tween returning. */}
-              <Button type="button" variant="ghost" onClick={goHome} aria-label="Back" className={`-ml-2 h-auto p-0 font-normal hover:bg-transparent grid size-12 place-items-center active:scale-90 ${M3_PRESS}`}><ArrowLeft className="size-5" /></Button>
-              <span className="flex-1 truncate text-[19px] font-normal">{activeApp.title}</span>
+              {/* The system navigation bar below already owns Android Back. A second
+                  shell-level Back here performed the exact same goHome action and
+                  doubled the affordance in every app. Internal app navigation (for
+                  example Settings detail → Settings list) renders its own Back. */}
+              <span className="flex-1 truncate pl-1 text-[19px] font-normal">{activeApp.title}</span>
               {appActions.length > 0 && (
                 <>
                 <Button type="button" variant="ghost" aria-label="Ask Alfa" onClick={toggleInspector} className={`h-auto p-0 font-normal hover:bg-transparent grid size-12 place-items-center active:scale-90 ${M3_PRESS}`}><Sparkles className="size-5" /></Button>
@@ -205,7 +208,7 @@ function AndroidShell() {
               </>
               )}
             </header>
-            <main className="relative min-h-0 flex-1 overflow-auto [container-type:inline-size]">
+            <main className="relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto [container-type:inline-size]">
               <WindowContent app={top.app} payload={top.payload} />
             </main>
             <NavBar onBack={goHome} onHome={goHome} onRecents={() => setRecents(true)} />

--- a/frontend/slices/appshell/features/notifications/components/dynamic-island.tsx
+++ b/frontend/slices/appshell/features/notifications/components/dynamic-island.tsx
@@ -29,7 +29,7 @@ export function DynamicIsland() {
         disabled={!a.appId}
         onClick={() => a.appId && openAppById(a.appId)}
         className="glass h-auto hover:bg-black/85 pointer-events-auto flex max-w-[80%] items-center gap-2.5 rounded-full bg-black/85 px-3.5 py-2 text-white shadow-xl disabled:cursor-default"
-        style={{ animation: "appOpen var(--shell-dur) var(--shell-ease)" }}
+        style={{ animation: "mobileAppOpen var(--shell-dur) var(--shell-ease)" }}
       >
         <span className="grid size-5 shrink-0 place-items-center">
           {tone === "done" ? (

--- a/frontend/slices/appshell/primitives/app-frame.tsx
+++ b/frontend/slices/appshell/primitives/app-frame.tsx
@@ -35,7 +35,7 @@ export function AppFrame({
       )}
       <div
         className={cn(
-          "min-h-0 flex-1 overflow-auto",
+          "min-h-0 flex-1 overflow-x-hidden overflow-y-auto",
           safeArea && "[padding-bottom:var(--sai-bottom)]",
           bodyClassName,
         )}

--- a/frontend/slices/appshell/responsive/responsive-provider.test.ts
+++ b/frontend/slices/appshell/responsive/responsive-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sameGeometry } from "./responsive-provider";
+import { sameGeometry, shouldUseMobileSurface } from "./responsive-provider";
 import type { Responsive } from "./use-responsive";
 
 const base: Responsive = {
@@ -37,5 +37,31 @@ describe("sameGeometry", () => {
     ["breakpoint", { breakpoint: "md" as const }],
   ])("is false when %s changes", (_label, patch) => {
     expect(sameGeometry(base, { ...base, ...patch })).toBe(false);
+  });
+});
+
+
+describe("shouldUseMobileSurface", () => {
+  it("uses mobile for portrait phones and desktop for the same phone rotated landscape", () => {
+    expect(shouldUseMobileSurface("phone", 390, 844, true)).toBe(true);
+    expect(shouldUseMobileSurface("phone", 844, 390, true)).toBe(false);
+  });
+
+  it("keeps the explicit Phone preview framed on a wide desktop viewport", () => {
+    expect(shouldUseMobileSurface("phone", 1280, 800, false)).toBe(true);
+  });
+
+  it("keeps auto phone-width portrait mobile but makes phone-width landscape desktop", () => {
+    expect(shouldUseMobileSurface("auto", 390, 844, true)).toBe(true);
+    expect(shouldUseMobileSurface("auto", 667, 375, true)).toBe(false);
+  });
+
+  it("still treats a coarse portrait tablet below 1024px as mobile", () => {
+    expect(shouldUseMobileSurface("auto", 820, 1180, true)).toBe(true);
+    expect(shouldUseMobileSurface("auto", 820, 1180, false)).toBe(false);
+  });
+
+  it("desktop override always stays desktop", () => {
+    expect(shouldUseMobileSurface("desktop", 390, 844, true)).toBe(false);
   });
 });

--- a/frontend/slices/appshell/responsive/responsive-provider.tsx
+++ b/frontend/slices/appshell/responsive/responsive-provider.tsx
@@ -12,6 +12,20 @@ import {
 export const MOBILE_W = 768; // phone-width cutoff — THE breakpoint (useIsMobile fallback imports it)
 const TABLET_W = 1024; // touch-portrait tablets below this read as mobile
 
+/** Whole-shell surface policy. Phones are mobile only in portrait; landscape is
+ * deliberately the desktop surface so a rotated phone gets the denser desktop
+ * workspace instead of a stretched phone shell. A forced phone preview follows
+ * the same rule — the override selects the portrait persona, not orientation. */
+export function shouldUseMobileSurface(device: DeviceMode, vw: number, vh: number, coarse: boolean): boolean {
+  const portrait = vh >= vw;
+  if (device === "desktop") return false;
+  // Keep the explicit Phone preview usable on a wide desktop: it renders inside
+  // PhoneFrame. On an actual phone-width landscape viewport, switch to desktop.
+  if (device === "phone") return portrait || vw >= TABLET_W;
+  if (!portrait) return false;
+  return vw < MOBILE_W || (coarse && vw < TABLET_W);
+}
+
 function bucket(vw: number): Pane {
   if (vw < 480) return "xs";
   if (vw < MOBILE_W) return "sm";
@@ -90,8 +104,7 @@ export function ResponsiveProvider({
       const vh = window.innerHeight;
       const coarse = window.matchMedia?.("(pointer: coarse)").matches ?? false;
       const portrait = vh >= vw;
-      const auto = vw < MOBILE_W || (coarse && portrait && vw < TABLET_W);
-      const isMobile = device === "phone" ? true : device === "desktop" ? false : auto;
+      const isMobile = shouldUseMobileSurface(device, vw, vh, coarse);
       const next: Responsive = {
         formFactor: isMobile ? "mobile" : "desktop",
         isMobile,

--- a/frontend/slices/appshell/responsive/use-is-mobile.ts
+++ b/frontend/slices/appshell/responsive/use-is-mobile.ts
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { ResponsiveContext } from "./use-responsive";
-import { MOBILE_W as MOBILE_BREAKPOINT } from "./responsive-provider";
+import { shouldUseMobileSurface } from "./responsive-provider";
 
 // True when the viewport is phone-sized. Inside the shell this reads the single
 // <ResponsiveProvider> source of truth; outside it (rare — a standalone preview,
@@ -15,11 +15,17 @@ export function useIsMobile(): boolean {
 
   React.useEffect(() => {
     if (ctx) return; // provider drives it; no standalone listener needed
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => setFallback(window.innerWidth < MOBILE_BREAKPOINT);
+    const onChange = () => {
+      const coarse = window.matchMedia?.("(pointer: coarse)").matches ?? false;
+      setFallback(shouldUseMobileSurface("auto", window.innerWidth, window.innerHeight, coarse));
+    };
     onChange();
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
+    window.addEventListener("resize", onChange);
+    window.addEventListener("orientationchange", onChange);
+    return () => {
+      window.removeEventListener("resize", onChange);
+      window.removeEventListener("orientationchange", onChange);
+    };
   }, [ctx]);
 
   return ctx ? ctx.isMobile : fallback;

--- a/frontend/slices/assistant/CONTRACT.md
+++ b/frontend/slices/assistant/CONTRACT.md
@@ -161,7 +161,13 @@ Four reasons, and the third is the one that settles it:
 
 **Reaffirmed 2026-08-20** when MCP gained global project/skill discovery: capability
 scoping stayed deleted on both surfaces, and the removed MSO image generation was NOT
-replaced by a per-agent toggle. **Done 2026-07-30.** The tool picker, the "Generalist / Curated — by skill" switch,
+replaced by a per-agent toggle.
+
+**Extended 2026-08-21 for project function calling:** project-specific function names
+remain DATA, never additions/removals to the model tool array. MCP exposes the stable
+`project_capabilities` + `project_function_call` pair; a project may opt in with
+`.mso/functions.json`. Alfa keeps its existing stable host catalog and can use project
+skills/files + approved `exec.run`; no project switch changes its cached tool prefix. **Done 2026-07-30.** The tool picker, the "Generalist / Curated — by skill" switch,
 the per-agent Skills grant list and every string that counted tools per agent are
 gone; `toolsForAgent()` went with them. `agent.allTools` and `agent.skills` remain on
 the type because they are persisted and `store-migration.test.ts` covers them — they

--- a/frontend/slices/os-settings/components/mcp-audit-section.tsx
+++ b/frontend/slices/os-settings/components/mcp-audit-section.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Activity, CheckCircle2, XCircle } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { SettingsBlock, SettingsSection } from "@/features/shell-settings";
+
+export type McpAuditRow = {
+  ts?: string;
+  action: string;
+  actor?: string | null;
+  target?: string;
+  ok?: boolean;
+  detail?: string;
+};
+
+export function McpAuditSection({ trail }: { trail: McpAuditRow[] }) {
+  return (
+    <SettingsSection
+      icon={<Activity />}
+      title="Recent activity"
+      footnote={<>This forensic trail records privileged mutations and denials. Assistant → MCP shows the live stream for every tool call, including reads. Full trail: <code className="font-mono">mso audit</code>.</>}
+    >
+      <SettingsBlock className="p-0">
+        <div className="flex min-h-[46px] items-center justify-between gap-3 border-b border-border/60 px-4 py-2.5">
+          <div>
+            <p className="text-[13px] font-medium">Privileged MCP log</p>
+            <p className="text-[10px] text-muted-foreground">Newest events first</p>
+          </div>
+          <span className="shrink-0 rounded-md bg-secondary px-2 py-1 text-[10px] text-muted-foreground">Latest {trail.length}</span>
+        </div>
+        {trail.length === 0 ? (
+          <div className="grid min-h-32 place-items-center px-4 py-8 text-center text-xs text-muted-foreground">
+            No privileged MCP activity yet.
+          </div>
+        ) : (
+          <ScrollArea aria-label="MCP audit log" className="h-72 max-h-[42dvh]">
+            <ul className="divide-y divide-border/60 pr-2">
+              {trail.map((entry, index) => {
+                const failed = entry.ok === false;
+                const StatusIcon = failed ? XCircle : CheckCircle2;
+                return (
+                  <li key={`${entry.ts ?? "event"}-${index}`} className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-2.5 gap-y-1 px-4 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto]">
+                    <StatusIcon className={failed ? "mt-0.5 size-3.5 text-destructive" : "mt-0.5 size-3.5 text-success"} />
+                    <div className="min-w-0">
+                      <code className={failed ? "font-mono text-[11px] font-medium text-destructive" : "font-mono text-[11px] font-medium"}>{entry.action}</code>
+                      {(entry.target || entry.detail) && (
+                        <p className="mt-0.5 line-clamp-2 break-all font-mono text-[10px] leading-relaxed text-muted-foreground">{entry.target ?? entry.detail}</p>
+                      )}
+                      {entry.actor && <p className="mt-0.5 truncate text-[10px] text-muted-foreground">{entry.actor}</p>}
+                    </div>
+                    <time className="col-start-2 shrink-0 text-[10px] text-muted-foreground sm:col-start-3 sm:row-start-1">
+                      {entry.ts ? new Date(entry.ts).toLocaleString() : ""}
+                    </time>
+                  </li>
+                );
+              })}
+            </ul>
+          </ScrollArea>
+        )}
+      </SettingsBlock>
+    </SettingsSection>
+  );
+}

--- a/frontend/slices/os-settings/components/mcp-connection-section.tsx
+++ b/frontend/slices/os-settings/components/mcp-connection-section.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy, Plug, Wrench } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { SettingsBlock, SettingsSection } from "@/features/shell-settings";
+import { McpToolsetCard, type McpToolsetInfo } from "./mcp-toolset-card";
+
+function CopyRow({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <SettingsBlock className="flex flex-col gap-2.5 sm:flex-row sm:items-center">
+      <span className="shrink-0 text-[13px] font-medium sm:w-32">{label}</span>
+      <div className="min-w-0 flex-1 rounded-lg bg-secondary/60 px-3 py-2">
+        <code className="block break-all font-mono text-[11px] leading-relaxed text-secondary-foreground sm:text-xs">{value}</code>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label={`Copy ${label}`}
+        className="size-9 shrink-0 self-end sm:self-auto [@media(pointer:coarse)]:size-11"
+        onClick={() => {
+          void navigator.clipboard.writeText(value).then(() => {
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1500);
+          });
+        }}
+      >
+        {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+      </Button>
+    </SettingsBlock>
+  );
+}
+
+export function McpConnectionSection({
+  origin,
+  maxScope,
+  toolset,
+}: {
+  origin: string;
+  maxScope: string;
+  toolset: McpToolsetInfo;
+}) {
+  return (
+    <div className="space-y-4 sm:space-y-5">
+      <SettingsSection
+        icon={<Plug />}
+        title="Connection"
+        footnote={<>Highest scope this server will mint: <strong>{maxScope}</strong> (<code className="font-mono">OS_MCP_MAX_SCOPE</code>).</>}
+      >
+        <SettingsBlock className="space-y-1.5 py-4">
+          <p className="text-sm font-medium">Connect ChatGPT with User-Defined OAuth</p>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            In ChatGPT open Settings → Connectors → New App. Use OAuth, leave Client Secret empty, and set token endpoint authentication to none.
+          </p>
+        </SettingsBlock>
+        <CopyRow label="MCP Server URL" value={`${origin}/mcp`} />
+        <CopyRow label="Auth URL" value={`${origin}/oauth/authorize`} />
+        <CopyRow label="Token URL" value={`${origin}/oauth/token`} />
+        <CopyRow label="Resource" value={`${origin}/mcp`} />
+        <CopyRow label="Client ID" value="chatgpt-mso" />
+        <SettingsBlock className="space-y-1.5 py-4">
+          <p className="text-[13px] font-medium">Other MCP clients</p>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Claude.ai, Cursor and mcp-remote register themselves. Give them <code className="break-all font-mono">{origin}/mcp</code> and nothing else.
+          </p>
+        </SettingsBlock>
+      </SettingsSection>
+
+      <SettingsSection icon={<Wrench />} title="Toolset status" bare>
+        <McpToolsetCard info={toolset} />
+      </SettingsSection>
+    </div>
+  );
+}

--- a/frontend/slices/os-settings/components/mcp-section.tsx
+++ b/frontend/slices/os-settings/components/mcp-section.tsx
@@ -1,91 +1,48 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Plug, Copy, Check } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { SettingsSection } from "@/features/shell-settings";
+import { Plug } from "lucide-react";
+import { SettingsBlock, SettingsSection } from "@/features/shell-settings";
 import { toast } from "@/features/os-shell";
 import { IS_DEMO } from "@/lib/demo";
-import { McpToolsetCard, type McpToolsetInfo } from "./mcp-toolset-card";
+import { McpAuditSection, type McpAuditRow } from "./mcp-audit-section";
+import { McpConnectionSection } from "./mcp-connection-section";
+import { McpTokenSection, type McpTokenRow } from "./mcp-token-section";
+import type { McpToolsetInfo } from "./mcp-toolset-card";
 
-type AuditRow = {
-  ts?: string;
-  action: string;
-  actor?: string | null;
-  target?: string;
-  ok?: boolean;
-  detail?: string;
+type McpState = {
+  enabled: boolean;
+  maxScope: string;
+  toolset: McpToolsetInfo;
+  tokens: McpTokenRow[];
 };
-
-type TokenRow = {
-  id: string;
-  label: string;
-  clientId: string;
-  scope: string;
-  createdAt: number;
-  expiresAt: number;
-  lastUsedAt?: number;
-  status: "active" | "revoked" | "expired";
-};
-
-const fmt = (t?: number) => (t ? new Date(t).toLocaleString() : "—");
-
-function CopyRow({ label, value }: { label: string; value: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <div className="flex items-center gap-2 py-1.5">
-      <span className="w-40 shrink-0 text-xs text-muted-foreground">{label}</span>
-      <code className="min-w-0 flex-1 truncate rounded bg-secondary px-2 py-1 font-mono text-[11px]">{value}</code>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        aria-label={`Copy ${label}`}
-        className="size-8 shrink-0 [@media(pointer:coarse)]:size-11"
-        onClick={() => {
-          void navigator.clipboard.writeText(value).then(() => {
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
-          });
-        }}
-      >
-        {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-      </Button>
-    </div>
-  );
-}
 
 export function McpSection() {
-  const [state, setState] = useState<{ enabled: boolean; maxScope: string; toolset: McpToolsetInfo; tokens: TokenRow[] } | null>(null);
-  const [trail, setTrail] = useState<AuditRow[]>([]);
+  const [state, setState] = useState<McpState | null>(null);
+  const [trail, setTrail] = useState<McpAuditRow[]>([]);
   const [origin, setOrigin] = useState("");
 
   const load = useCallback(() => {
     if (IS_DEMO) return;
     fetch("/api/mcp/tokens", { cache: "no-store" })
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((s) => {
-        // Read the origin here rather than in the effect body: window.location is
-        // an impure render-time read, and a synchronous setState in an effect is a
-        // cascading render. Both are lint errors, and both are avoidable by doing
-        // it once, in the callback that already updates this component.
+      .then((response) => (response.ok ? response.json() : Promise.reject(new Error(`HTTP ${response.status}`))))
+      .then((next: McpState) => {
         setOrigin(window.location.origin);
-        setState(s);
+        setState(next);
       })
       .catch(() => toast("Couldn't load MCP tokens", { tone: "error" }));
-    // What those tokens actually DID. Revoking is a weak control if you cannot
-    // see the writes and commands that already went through.
+
     fetch("/api/v1/sys/audit?actor=mcp%3A&limit=20", { cache: "no-store" })
-      .then((r) => (r.ok ? r.json() : { entries: [] }))
-      .then((d: { entries?: AuditRow[] }) => setTrail(d.entries ?? []))
+      .then((response) => (response.ok ? response.json() : { entries: [] }))
+      .then((data: { entries?: McpAuditRow[] }) => setTrail(data.entries ?? []))
       .catch(() => setTrail([]));
   }, []);
 
   useEffect(load, [load]);
 
   async function revoke(id: string, what: string) {
-    const r = await fetch(`/api/mcp/tokens?id=${encodeURIComponent(id)}`, { method: "DELETE" });
-    if (!r.ok) {
+    const response = await fetch(`/api/mcp/tokens?id=${encodeURIComponent(id)}`, { method: "DELETE" });
+    if (!response.ok) {
       toast(`Couldn't revoke ${what}`, { tone: "error" });
       return;
     }
@@ -93,106 +50,52 @@ export function McpSection() {
     load();
   }
 
-  const live = state?.tokens.filter((t) => t.status === "active") ?? [];
+  if (IS_DEMO) {
+    return (
+      <SettingsSection icon={<Plug />} title="MCP connection">
+        <SettingsBlock className="space-y-1.5 py-4">
+          <p className="text-sm font-medium">MCP is unavailable in demo mode</p>
+          <p className="text-xs leading-relaxed text-muted-foreground">Connect to a live MSO host to configure OAuth, inspect tokens, and review MCP activity.</p>
+        </SettingsBlock>
+      </SettingsSection>
+    );
+  }
+
+  if (!state) {
+    return (
+      <SettingsSection icon={<Plug />} title="MCP connection">
+        <SettingsBlock>
+          <div className="space-y-2" aria-live="polite">
+            <div className="h-4 w-40 animate-pulse rounded bg-secondary" />
+            <div className="h-3 w-3/4 animate-pulse rounded bg-secondary/70" />
+          </div>
+        </SettingsBlock>
+      </SettingsSection>
+    );
+  }
+
+  if (!state.enabled) {
+    return (
+      <SettingsSection
+        icon={<Plug />}
+        title="MCP connection"
+        footnote="When disabled, the MCP endpoint and OAuth discovery documents return 404, so no unauthenticated MCP surface remains exposed."
+      >
+        <SettingsBlock className="space-y-2 py-4">
+          <p className="text-sm font-medium">MCP is disabled</p>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Set <code className="font-mono">OS_MCP_ENABLED=1</code> in <code className="font-mono">.env.local</code> and restart <code className="font-mono">mso.service</code>.
+          </p>
+        </SettingsBlock>
+      </SettingsSection>
+    );
+  }
 
   return (
-    <SettingsSection
-      icon={<Plug />}
-      title="MCP — control this VPS from ChatGPT"
-      footnote="Tokens are stored as a hash; the raw value is shown to the client once, at mint. Revoking is immediate — it is re-checked on every call."
-    >
-      {!state?.enabled ? (
-        <p className="text-xs text-muted-foreground">
-          Disabled. Set <code className="font-mono">OS_MCP_ENABLED=1</code> in <code className="font-mono">.env.local</code>{" "}
-          and restart mso.service. While it is off, <code className="font-mono">/mcp</code> and the OAuth
-          discovery documents return 404 — there is no MCP surface at all, not an unauthenticated one.
-        </p>
-      ) : (
-        <>
-          <div className="space-y-0.5">
-            <p className="pb-1 text-xs text-muted-foreground">
-              In ChatGPT: Settings → Connectors → New App. Authentication <strong>OAuth</strong>, registration{" "}
-              <strong>User-Defined OAuth Client</strong>, Client Secret <strong>empty</strong>, token endpoint auth{" "}
-              <strong>none</strong>.
-            </p>
-            <CopyRow label="MCP Server URL" value={`${origin}/mcp`} />
-            <CopyRow label="Auth URL" value={`${origin}/oauth/authorize`} />
-            <CopyRow label="Token URL" value={`${origin}/oauth/token`} />
-            <CopyRow label="Resource" value={`${origin}/mcp`} />
-            <CopyRow label="Client ID" value="chatgpt-mso" />
-            <p className="pt-1 text-xs text-muted-foreground">
-              Claude.ai, Cursor and mcp-remote register themselves — give them{" "}
-              <code className="font-mono">{origin}/mcp</code> and nothing else. Highest tier this server will
-              mint: <strong>{state.maxScope}</strong> (<code className="font-mono">OS_MCP_MAX_SCOPE</code>).
-            </p>
-            <McpToolsetCard info={state.toolset} />
-          </div>
-
-          <div className="mt-3 border-t border-border pt-3">
-            {state.tokens.length === 0 ? (
-              <p className="text-xs text-muted-foreground">
-                No tokens yet. One is minted when you approve a client on the consent screen.
-              </p>
-            ) : (
-              <ul className="space-y-1.5">
-                {state.tokens.map((t) => {
-                  const dead = t.status !== "active";
-                  return (
-                    <li key={t.id} className="flex items-center gap-2 text-xs">
-                      <span className={dead ? "min-w-0 flex-1 truncate text-muted-foreground line-through" : "min-w-0 flex-1 truncate"}>
-                        {t.label}
-                        <span className="ml-1.5 rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px]">{t.scope}</span>
-                      </span>
-                      <span className="hidden shrink-0 text-muted-foreground sm:inline">last used {fmt(t.lastUsedAt)}</span>
-                      {dead ? (
-                        <span className="shrink-0 text-muted-foreground">{t.status}</span>
-                      ) : (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 shrink-0 text-destructive [@media(pointer:coarse)]:min-h-[44px]"
-                          onClick={() => void revoke(t.id, t.label)}
-                        >
-                          Revoke
-                        </Button>
-                      )}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            {trail.length > 0 && (
-              <div className="mt-4 border-t border-border pt-3">
-                <p className="pb-1.5 text-xs font-medium">Recent MCP activity</p>
-                <ul className="space-y-1">
-                  {trail.map((e, i) => (
-                    <li key={i} className="flex items-baseline gap-2 text-[11px]">
-                      <code className={e.ok === false ? "shrink-0 font-mono text-destructive" : "shrink-0 font-mono"}>{e.action}</code>
-                      <span className="min-w-0 flex-1 truncate font-mono text-muted-foreground">{e.target ?? e.detail ?? ""}</span>
-                      <span className="shrink-0 text-muted-foreground">{e.ts ? new Date(e.ts).toLocaleString() : ""}</span>
-                    </li>
-                  ))}
-                </ul>
-                <p className="pt-1.5 text-[11px] text-muted-foreground">
-                  This forensic trail still records privileged mutations and denials. The Assistant → MCP tab adds a separate live activity stream for all tool calls, including reads. Full forensic trail: <code className="font-mono">mso audit</code>.
-                </p>
-              </div>
-            )}
-            {live.length > 0 && (
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                className="mt-3 w-full text-destructive [@media(pointer:coarse)]:min-h-[44px]"
-                onClick={() => void revoke("all", `all ${live.length} live token(s)`)}
-              >
-                Revoke all ({live.length})
-              </Button>
-            )}
-          </div>
-        </>
-      )}
-    </SettingsSection>
+    <div className="space-y-4 sm:space-y-5">
+      <McpConnectionSection origin={origin} maxScope={state.maxScope} toolset={state.toolset} />
+      <McpTokenSection tokens={state.tokens} onRevoke={revoke} />
+      <McpAuditSection trail={trail} />
+    </div>
   );
 }

--- a/frontend/slices/os-settings/components/mcp-token-section.tsx
+++ b/frontend/slices/os-settings/components/mcp-token-section.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { KeyRound } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { SettingsActionRow, SettingsBlock, SettingsSection } from "@/features/shell-settings";
+
+export type McpTokenRow = {
+  id: string;
+  label: string;
+  clientId: string;
+  scope: string;
+  createdAt: number;
+  expiresAt: number;
+  lastUsedAt?: number;
+  status: "active" | "revoked" | "expired";
+};
+
+const formatTime = (time?: number) => (time ? new Date(time).toLocaleString() : "Never");
+
+export function McpTokenSection({
+  tokens,
+  onRevoke,
+}: {
+  tokens: McpTokenRow[];
+  onRevoke: (id: string, what: string) => Promise<void>;
+}) {
+  const live = tokens.filter((token) => token.status === "active");
+  return (
+    <SettingsSection
+      icon={<KeyRound />}
+      title={`Access tokens (${tokens.length})`}
+      footnote="Tokens are stored as hashes; the raw value is shown once when minted. Revocation is checked on every MCP call."
+    >
+      {tokens.length === 0 ? (
+        <SettingsBlock className="py-4">
+          <p className="text-xs leading-relaxed text-muted-foreground">No tokens yet. One is minted after you approve a client on the OAuth consent screen.</p>
+        </SettingsBlock>
+      ) : (
+        tokens.map((token) => {
+          const inactive = token.status !== "active";
+          return (
+            <SettingsBlock key={token.id} className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center">
+              <div className="min-w-0 flex-1 space-y-1">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className={inactive ? "text-sm font-medium text-muted-foreground line-through" : "text-sm font-medium"}>{token.label}</span>
+                  <span className="rounded-md bg-secondary px-2 py-0.5 font-mono text-[10px]">{token.scope}</span>
+                  {inactive && <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{token.status}</span>}
+                </div>
+                <p className="break-all font-mono text-[10px] leading-relaxed text-muted-foreground">{token.clientId}</p>
+                <p className="text-[11px] leading-relaxed text-muted-foreground">
+                  Last used {formatTime(token.lastUsedAt)} · expires {formatTime(token.expiresAt)}
+                </p>
+              </div>
+              {!inactive && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="min-h-9 shrink-0 self-end text-destructive sm:self-auto [@media(pointer:coarse)]:min-h-[44px]"
+                  onClick={() => void onRevoke(token.id, token.label)}
+                >
+                  Revoke
+                </Button>
+              )}
+            </SettingsBlock>
+          );
+        })
+      )}
+      {live.length > 0 && (
+        <SettingsActionRow
+          label={`Revoke all (${live.length})`}
+          tone="destructive"
+          onClick={() => void onRevoke("all", `all ${live.length} live token(s)`)}
+        />
+      )}
+    </SettingsSection>
+  );
+}

--- a/frontend/slices/os-settings/components/mcp-toolset-card.tsx
+++ b/frontend/slices/os-settings/components/mcp-toolset-card.tsx
@@ -34,19 +34,19 @@ export function McpToolsetCard({ info }: { info: McpToolsetInfo }) {
   const changed = Boolean(ack && !current);
 
   return (
-    <div className="mt-3 rounded-xl border border-border bg-secondary/30 p-3">
+    <div className="rounded-xl border border-border/70 bg-card p-4 shadow-sm">
       <div className="flex items-start gap-2">
         <Wrench className="mt-0.5 size-4 shrink-0" />
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <p className="text-xs font-medium">MCP toolset {info.version}</p>
-            <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px]">{info.toolCount} tools</span>
-            <span className="font-mono text-[10px] text-muted-foreground">{info.hash}</span>
+            <p className="text-sm font-medium">MCP toolset {info.version}</p>
+            <span className="rounded-md bg-secondary px-2 py-0.5 font-mono text-[11px]">{info.toolCount} tools</span>
+            <span className="font-mono text-[11px] text-muted-foreground">{info.hash}</span>
           </div>
-          <p className="mt-1 text-[11px] text-muted-foreground">
+          <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
             Server {info.serverVersion} · read {info.byScope.read} · write {info.byScope.write} · exec {info.byScope.exec} · changed {info.changedAt.slice(0, 10)}
           </p>
-          <p className={`mt-1 text-[11px] ${changed ? "text-warning" : "text-muted-foreground"}`}>
+          <p className={`mt-2 text-xs leading-relaxed ${changed ? "text-warning" : "text-muted-foreground"}`}>
             {current
               ? "ChatGPT action snapshot marked current for this browser."
               : changed
@@ -56,15 +56,15 @@ export function McpToolsetCard({ info }: { info: McpToolsetInfo }) {
         </div>
         {current ? <BadgeCheck className="size-4 shrink-0 text-success" /> : <RefreshCw className="size-4 shrink-0 text-warning" />}
       </div>
-      <div className="mt-2 flex gap-2">
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row">
         <Button
-          type="button" variant="secondary" size="sm" className="h-8 text-[11px]"
+          type="button" variant="secondary" size="sm" className="min-h-9 flex-1 text-xs sm:flex-none [@media(pointer:coarse)]:min-h-[44px]"
           onClick={() => { window.localStorage.setItem(ACK_KEY, signature); window.dispatchEvent(new Event(ACK_EVENT)); }}
         >
           {current ? "Marked refreshed" : "Mark ChatGPT refreshed"}
         </Button>
         <Button
-          type="button" variant="ghost" size="sm" className="h-8 text-[11px]"
+          type="button" variant="ghost" size="sm" className="min-h-9 flex-1 text-xs sm:flex-none [@media(pointer:coarse)]:min-h-[44px]"
           onClick={() => void navigator.clipboard.writeText(signature).then(() => {
             setCopied(true); window.setTimeout(() => setCopied(false), 1500);
           })}

--- a/frontend/slices/os-shell/brand-marks.tsx
+++ b/frontend/slices/os-shell/brand-marks.tsx
@@ -3,27 +3,9 @@
 // Raster app artwork is intentionally WebP. Toolbar/menu/control glyphs stay
 // vector (Lucide), while app icons are allowed to carry richer platform-specific
 // illustration. macOS and Windows do NOT share the same art direction: the shell
-// chooses the correct image through data-shell CSS. Other shells keep the generic
-// fallback artwork until they receive their own generated set.
+// chooses the correct image through data-shell CSS. Mobile intentionally reuses
+// those families: iOS = macOS artwork, Android = Windows artwork.
 import type { AppIconComponent } from "@/features/appshell";
-
-function mark(src: string): AppIconComponent {
-  const Mark: AppIconComponent = ({ className: cls }) => (
-    // Tiny fixed local artwork; next/image would add optimizer overhead with no
-    // visual or transfer-size win at these dimensions.
-    // eslint-disable-next-line @next/next/no-img-element
-    <img
-      src={src}
-      alt=""
-      aria-hidden
-      className={cls ?? "size-full object-contain"}
-      draggable={false}
-      decoding="async"
-    />
-  );
-  Mark.displayName = `AppArtwork(${src})`;
-  return Mark;
-}
 
 /** One app identity with distinct native-looking artwork per desktop shell. */
 function platformMark(fallback: string, macos: string, windows: string): AppIconComponent {
@@ -50,7 +32,7 @@ export const APP_MARKS: Record<string, AppIconComponent> = {
     "/app-icons/macos/files.webp",
     "/app-icons/windows/files.webp",
   ),
-  "camoufox-browser": mark("/brand/official/camoufox.webp"),
+  "camoufox-browser": platformMark("/brand/official/camoufox.webp", "/app-icons/macos/camoufox.webp", "/app-icons/windows/camoufox.webp"),
   "code-editor": platformMark(
     "/app-icons/code.webp",
     "/app-icons/macos/code.webp",
@@ -96,8 +78,8 @@ export const APP_MARKS: Record<string, AppIconComponent> = {
     "/app-icons/macos/docs.webp",
     "/app-icons/windows/docs.webp",
   ),
-  hermes: mark("/brand/official/hermes.webp"),
-  openclaw: mark("/brand/official/openclaw.webp"),
+  hermes: platformMark("/brand/official/hermes.webp", "/app-icons/macos/hermes.webp", "/app-icons/windows/hermes.webp"),
+  openclaw: platformMark("/brand/official/openclaw.webp", "/app-icons/macos/openclaw.webp", "/app-icons/windows/openclaw.webp"),
 };
 
 export const HermesMark = APP_MARKS.hermes;

--- a/frontend/slices/reel-editor/components/menu-bar.tsx
+++ b/frontend/slices/reel-editor/components/menu-bar.tsx
@@ -72,7 +72,7 @@ export function MenuBar(p: MenuBarProps) {
   const shortcuts = "Space play · S split · ⌘Z undo · ⌘⇧Z redo · ⌘D duplicate · ⌫ delete";
 
   return (
-    <header className="flex items-center gap-1 border-b border-border bg-card px-2 py-1">
+    <header className="flex min-w-0 items-center gap-1 overflow-x-auto border-b border-border bg-card px-2 py-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
       <FilePicker ref={imgRef} accept="image/*" onFiles={onFiles("image")} />
       <FilePicker ref={vidRef} accept="video/*" onFiles={onFiles("video")} />
       <FilePicker ref={audRef} accept="audio/*" onFiles={onFiles("audio")} />

--- a/lib/host/bounded-read.ts
+++ b/lib/host/bounded-read.ts
@@ -24,6 +24,8 @@ export const BOUNDED_READ = {
   gitHead: 4 * 1024,
   gitRef: 4 * 1024,
   packedRefs: 1024 * 1024,
+  projectFunctions: 256 * 1024,
+  projectMcpConfig: 256 * 1024,
 } as const;
 
 export async function readBoundedRegularFile(file: string, maxBytes: number): Promise<string | null> {

--- a/lib/host/index.ts
+++ b/lib/host/index.ts
@@ -11,6 +11,8 @@ export { runCommand } from "./exec";
 export { sha256Text, utf8Bytes } from "./hash";
 export { writeFileGuarded } from "./guarded-write";
 export { resolveProjectHint, inspectProject } from "./projects";
+export { projectCapabilities, runProjectFunction } from "./project-capabilities";
+export type { ProjectCapabilities, PublicProjectFunction } from "./project-capabilities";
 export { listProjects, listProjectDirs, projectRoots, PROJECT_LIMITS } from "./project-roots";
 export type { ProjectRow, ListProjectsResult } from "./project-roots";
 export { normalizeProjectKey, projectAliasesFor, projectAliasTarget } from "./project-aliases";

--- a/lib/host/project-capabilities.test.ts
+++ b/lib/host/project-capabilities.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import { projectCapabilities, runProjectFunction } from "./project-capabilities";
+
+const roots: string[] = [];
+afterEach(async () => { await Promise.all(roots.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true }))); });
+
+async function project() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "mso-project-cap-"));
+  roots.push(dir);
+  await fs.mkdir(path.join(dir, ".mso"));
+  return dir;
+}
+
+const manifest = (command: string[]) => ({
+  version: 1,
+  functions: [{
+    name: "echo_payload",
+    description: "Echo the JSON payload received on stdin.",
+    inputSchema: { type: "object", properties: { value: { type: "string" } }, required: ["value"], additionalProperties: false },
+    command,
+    timeoutMs: 5000,
+  }],
+});
+
+describe("project capability manifests", () => {
+  it("is invisible when a project did not opt in", async () => {
+    const dir = await project();
+    expect(await projectCapabilities(dir)).toBeUndefined();
+  });
+
+  it("reports MCP + public function metadata without exposing argv or MCP contents", async () => {
+    const dir = await project();
+    await fs.writeFile(path.join(dir, ".mcp.json"), JSON.stringify({ mcpServers: { secretServer: { env: { TOKEN: "do-not-return" } } } }));
+    await fs.writeFile(path.join(dir, ".mso/functions.json"), JSON.stringify(manifest([process.execPath, "-e", ""])), { mode: 0o600 });
+    const capabilities = await projectCapabilities(dir);
+    expect(capabilities?.mcp).toEqual({ config: ".mcp.json" });
+    expect(capabilities?.functions).toMatchObject({ valid: true, version: 1, count: 1 });
+    const text = JSON.stringify(capabilities);
+    expect(text).toContain("echo_payload");
+    expect(text).not.toContain("do-not-return");
+    expect(text).not.toContain(process.execPath);
+  });
+
+  it("executes fixed argv with caller input on JSON stdin, never shell interpolation", async () => {
+    const dir = await project();
+    const code = "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>process.stdout.write(JSON.stringify({payload:JSON.parse(s),fn:process.env.MSO_PROJECT_FUNCTION})))";
+    await fs.writeFile(path.join(dir, ".mso/functions.json"), JSON.stringify(manifest([process.execPath, "-e", code])));
+    const payload = { value: "$(touch /tmp/should-not-run); hello" };
+    const result = await runProjectFunction(dir, "echo_payload", payload);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ payload, fn: "echo_payload" });
+  });
+
+  it("validates required fields and additionalProperties before spawning project code", async () => {
+    const dir = await project();
+    const code = "process.stdin.resume();process.stdin.on('end',()=>process.stdout.write('ran'))";
+    await fs.writeFile(path.join(dir, ".mso/functions.json"), JSON.stringify(manifest([process.execPath, "-e", code])));
+    await expect(runProjectFunction(dir, "echo_payload", {})).rejects.toThrow(/required input\.value/i);
+    await expect(runProjectFunction(dir, "echo_payload", { value: "x", surprise: true })).rejects.toThrow(/unknown input\.surprise/i);
+  });
+
+  it("fails closed on a symlinked .mso directory or invalid manifest", async () => {
+    const dir = await project();
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "mso-project-cap-outside-"));
+    roots.push(outside);
+    await fs.rm(path.join(dir, ".mso"), { recursive: true });
+    await fs.writeFile(path.join(outside, "functions.json"), JSON.stringify(manifest([process.execPath, "-e", ""])), { mode: 0o600 });
+    await fs.symlink(outside, path.join(dir, ".mso"));
+    expect(await projectCapabilities(dir)).toBeUndefined();
+    await expect(runProjectFunction(dir, "echo_payload", {})).rejects.toThrow(/no \.mso\/functions\.json/i);
+
+    const second = await project();
+    await fs.writeFile(path.join(second, ".mso/functions.json"), JSON.stringify({ version: 1, functions: [{ name: "BAD NAME" }] }));
+    expect(await projectCapabilities(second)).toMatchObject({ functions: { valid: false } });
+    await expect(runProjectFunction(second, "anything", {})).rejects.toThrow(/invalid|name/i);
+  });
+});

--- a/lib/host/project-capabilities.ts
+++ b/lib/host/project-capabilities.ts
@@ -1,0 +1,5 @@
+// Stable facade: discovery and execution live in separate modules so read-scope
+// manifest parsing cannot accidentally grow process-launch concerns.
+export { projectCapabilities } from "./project-function-manifest";
+export type { ProjectCapabilities, PublicProjectFunction } from "./project-function-manifest";
+export { runProjectFunction } from "./project-function-runner";

--- a/lib/host/project-containers.ts
+++ b/lib/host/project-containers.ts
@@ -63,6 +63,7 @@ export type ProjectRow = {
   packageName?: string;
   packageVersion?: string;
   git?: { branch?: string; head?: string };
+  capabilities?: import("./project-capabilities").ProjectCapabilities;
 };
 
 

--- a/lib/host/project-function-manifest.ts
+++ b/lib/host/project-function-manifest.ts
@@ -1,0 +1,126 @@
+// SERVER-ONLY. Opt-in capability metadata declared BY a project, not features
+// baked into MSO. Every file read is bounded/O_NOFOLLOW; MCP config contents are
+// never returned because they commonly contain credential wiring.
+import { promises as fs } from "fs";
+import path from "path";
+import { BOUNDED_READ, readBoundedRegularFile } from "./bounded-read";
+import { isUnderRoot } from "./paths";
+
+export const PROJECT_FUNCTIONS_REL = ".mso/functions.json" as const;
+export const PROJECT_MCP_REL = ".mcp.json" as const;
+const MAX_FUNCTIONS = 32;
+const MAX_ARGV = 16;
+const MAX_ARG = 512;
+const MAX_DESCRIPTION = 600;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export type ProjectFunction = {
+  name: string;
+  description: string;
+  inputSchema: { type: "object"; properties: Record<string, unknown>; required?: string[]; additionalProperties?: boolean };
+  command: string[];
+  timeoutMs: number;
+};
+
+export type PublicProjectFunction = Omit<ProjectFunction, "command">;
+export type ProjectCapabilities = {
+  mcp?: { config: typeof PROJECT_MCP_REL };
+  functions?:
+    | { manifest: typeof PROJECT_FUNCTIONS_REL; valid: true; version: 1; count: number; tools: PublicProjectFunction[] }
+    | { manifest: typeof PROJECT_FUNCTIONS_REL; valid: false; error: string };
+};
+export type ProjectFunctionsRead = { found: false } | { found: true; functions?: ProjectFunction[]; error?: string };
+
+const plainObject = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === "object" && !Array.isArray(value));
+
+async function projectMsoDir(projectPath: string): Promise<string | null> {
+  const candidate = path.join(projectPath, ".mso");
+  const stat = await fs.lstat(candidate).catch(() => null);
+  if (!stat?.isDirectory() || stat.isSymbolicLink()) return null;
+  const real = await fs.realpath(candidate).catch(() => null);
+  return real && isUnderRoot(real, projectPath) && real === path.resolve(candidate) ? real : null;
+}
+
+function parseInputSchema(value: unknown, functionName: string): ProjectFunction["inputSchema"] {
+  if (!plainObject(value) || value.type !== "object" || !plainObject(value.properties)) {
+    throw new Error(`${functionName}: inputSchema must be an object JSON Schema`);
+  }
+  const required = value.required;
+  if (required !== undefined && (!Array.isArray(required) || !required.every((item) => typeof item === "string"))) {
+    throw new Error(`${functionName}: inputSchema.required must be a string array`);
+  }
+  if (value.additionalProperties !== undefined && typeof value.additionalProperties !== "boolean") {
+    throw new Error(`${functionName}: inputSchema.additionalProperties must be boolean`);
+  }
+  return {
+    type: "object",
+    properties: value.properties,
+    ...(required ? { required: [...new Set(required)] } : {}),
+    ...(typeof value.additionalProperties === "boolean" ? { additionalProperties: value.additionalProperties } : {}),
+  };
+}
+
+function parseManifest(raw: string): ProjectFunction[] {
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { throw new Error("functions manifest is not valid JSON"); }
+  if (!plainObject(parsed) || parsed.version !== 1 || !Array.isArray(parsed.functions)) {
+    throw new Error("functions manifest must be {version:1, functions:[…]}");
+  }
+  if (parsed.functions.length > MAX_FUNCTIONS) throw new Error(`functions manifest exceeds ${MAX_FUNCTIONS} functions`);
+  const seen = new Set<string>();
+  return parsed.functions.map((value, index): ProjectFunction => {
+    if (!plainObject(value)) throw new Error(`functions[${index}] must be an object`);
+    const name = typeof value.name === "string" ? value.name.trim() : "";
+    if (!/^[a-z][a-z0-9_.-]{0,63}$/.test(name)) throw new Error(`functions[${index}].name is invalid`);
+    if (seen.has(name)) throw new Error(`duplicate function name: ${name}`);
+    seen.add(name);
+    const description = typeof value.description === "string" ? value.description.trim() : "";
+    if (!description || description.length > MAX_DESCRIPTION) throw new Error(`${name}: description must be 1-${MAX_DESCRIPTION} chars`);
+    const command = Array.isArray(value.command) ? value.command : [];
+    if (!command.length || command.length > MAX_ARGV || typeof command[0] !== "string" || command[0].length === 0 ||
+        !command.every((arg) => typeof arg === "string" && arg.length <= MAX_ARG && !arg.includes("\0"))) {
+      throw new Error(`${name}: command must have a non-empty executable plus at most ${MAX_ARGV - 1} fixed argv strings (max ${MAX_ARG} chars each)`);
+    }
+    const timeoutMs = value.timeoutMs === undefined ? DEFAULT_TIMEOUT_MS : Number(value.timeoutMs);
+    if (!Number.isInteger(timeoutMs) || timeoutMs < 1000 || timeoutMs > DEFAULT_TIMEOUT_MS) {
+      throw new Error(`${name}: timeoutMs must be 1000-${DEFAULT_TIMEOUT_MS}`);
+    }
+    return { name, description, inputSchema: parseInputSchema(value.inputSchema, name), command: [...command], timeoutMs };
+  });
+}
+
+export async function readProjectFunctionsManifest(projectPath: string): Promise<ProjectFunctionsRead> {
+  const mso = await projectMsoDir(projectPath);
+  if (!mso) return { found: false };
+  const file = path.join(mso, "functions.json");
+  const stat = await fs.lstat(file).catch(() => null);
+  if (!stat) return { found: false };
+  if (!stat.isFile() || stat.isSymbolicLink()) return { found: true, error: "functions manifest must be a regular non-symlink file" };
+  const raw = await readBoundedRegularFile(file, BOUNDED_READ.projectFunctions);
+  if (raw === null) return { found: true, error: `functions manifest is unreadable or exceeds ${BOUNDED_READ.projectFunctions} bytes` };
+  try { return { found: true, functions: parseManifest(raw) }; }
+  catch (error) { return { found: true, error: error instanceof Error ? error.message : "invalid functions manifest" }; }
+}
+
+async function hasMcpConfig(projectPath: string): Promise<boolean> {
+  const file = path.join(projectPath, PROJECT_MCP_REL);
+  const stat = await fs.lstat(file).catch(() => null);
+  if (!stat?.isFile() || stat.isSymbolicLink()) return false;
+  const raw = await readBoundedRegularFile(file, BOUNDED_READ.projectMcpConfig);
+  if (raw === null) return false;
+  try { return plainObject(JSON.parse(raw)); } catch { return false; }
+}
+
+export async function projectCapabilities(projectPath: string): Promise<ProjectCapabilities | undefined> {
+  const [mcp, fn] = await Promise.all([hasMcpConfig(projectPath), readProjectFunctionsManifest(projectPath)]);
+  const capabilities: ProjectCapabilities = {};
+  if (mcp) capabilities.mcp = { config: PROJECT_MCP_REL };
+  if (fn.found) {
+    capabilities.functions = fn.functions
+      ? { manifest: PROJECT_FUNCTIONS_REL, valid: true, version: 1, count: fn.functions.length,
+          tools: fn.functions.map(({ command: _command, ...tool }) => tool) }
+      : { manifest: PROJECT_FUNCTIONS_REL, valid: false, error: fn.error ?? "invalid functions manifest" };
+  }
+  return capabilities.mcp || capabilities.functions ? capabilities : undefined;
+}

--- a/lib/host/project-function-runner.ts
+++ b/lib/host/project-function-runner.ts
@@ -1,0 +1,95 @@
+// SERVER-ONLY. Exec-scope runner for ONE function from a project's opt-in
+// .mso/functions.json. Manifest argv is fixed project data; caller JSON travels
+// only on stdin. No shell, no interpolation, credential-scrubbed environment.
+import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
+import { childEnv } from "./child-env";
+import { PROJECT_FUNCTIONS_REL, readProjectFunctionsManifest, type ProjectFunction } from "./project-function-manifest";
+
+const MAX_INPUT_BYTES = 128 * 1024;
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+const plainObject = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === "object" && !Array.isArray(value));
+
+function typeMatches(type: unknown, value: unknown): boolean {
+  if (type === "string") return typeof value === "string";
+  if (type === "number") return typeof value === "number" && Number.isFinite(value);
+  if (type === "integer") return typeof value === "number" && Number.isInteger(value);
+  if (type === "boolean") return typeof value === "boolean";
+  if (type === "object") return plainObject(value);
+  if (type === "array") return Array.isArray(value);
+  if (type === "null") return value === null;
+  return true;
+}
+
+function validateInput(definition: ProjectFunction, input: Record<string, unknown>): void {
+  for (const required of definition.inputSchema.required ?? []) {
+    if (!Object.prototype.hasOwnProperty.call(input, required)) throw new Error(`${definition.name}: missing required input.${required}`);
+  }
+  if (definition.inputSchema.additionalProperties === false) {
+    const unknown = Object.keys(input).find((key) => !Object.prototype.hasOwnProperty.call(definition.inputSchema.properties, key));
+    if (unknown) throw new Error(`${definition.name}: unknown input.${unknown}`);
+  }
+  for (const [key, value] of Object.entries(input)) {
+    const property = definition.inputSchema.properties[key];
+    if (!plainObject(property)) continue;
+    if (!typeMatches(property.type, value)) throw new Error(`${definition.name}: input.${key} has wrong type`);
+    if (Array.isArray(property.enum) && !property.enum.some((candidate) => JSON.stringify(candidate) === JSON.stringify(value))) {
+      throw new Error(`${definition.name}: input.${key} is not an allowed enum value`);
+    }
+  }
+}
+
+export async function runProjectFunction(
+  projectPath: string,
+  name: string,
+  input: unknown,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const manifest = await readProjectFunctionsManifest(projectPath);
+  if (!manifest.found) throw new Error(`project has no ${PROJECT_FUNCTIONS_REL}`);
+  if (!manifest.functions) throw new Error(manifest.error ?? "invalid functions manifest");
+  const definition = manifest.functions.find((candidate) => candidate.name === name);
+  if (!definition) throw new Error(`unknown project function "${name}"`);
+  if (!plainObject(input)) throw new Error("input must be a JSON object");
+  validateInput(definition, input);
+  const payload = JSON.stringify(input);
+  if (Buffer.byteLength(payload) > MAX_INPUT_BYTES) throw new Error(`project function input exceeds ${MAX_INPUT_BYTES} bytes`);
+
+  return new Promise((resolve) => {
+    const child = spawn(definition.command[0], definition.command.slice(1), {
+      cwd: projectPath,
+      env: { ...childEnv(), MSO_PROJECT_FUNCTION: definition.name } as unknown as NodeJS.ProcessEnv,
+      shell: false,
+      stdio: ["pipe", "pipe", "pipe"],
+    }) as ChildProcessWithoutNullStreams;
+    let stdout = "", stderr = "", stdoutBytes = 0, stderrBytes = 0;
+    let finished = false, overflow = false, timedOut = false;
+    const append = (current: string, bytes: number, chunk: Buffer): [string, number] => {
+      const slice = chunk.subarray(0, Math.max(0, MAX_OUTPUT_BYTES - bytes));
+      return [current + slice.toString("utf8"), bytes + slice.byteLength];
+    };
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (stdoutBytes + chunk.byteLength > MAX_OUTPUT_BYTES) overflow = true;
+      [stdout, stdoutBytes] = append(stdout, stdoutBytes, chunk);
+      if (overflow) child.kill("SIGTERM");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      if (stderrBytes + chunk.byteLength > MAX_OUTPUT_BYTES) overflow = true;
+      [stderr, stderrBytes] = append(stderr, stderrBytes, chunk);
+      if (overflow) child.kill("SIGTERM");
+    });
+    const timer = setTimeout(() => { if (!finished) { timedOut = true; child.kill("SIGTERM"); } }, definition.timeoutMs);
+    child.on("error", (error: Error) => {
+      if (finished) return;
+      finished = true; clearTimeout(timer);
+      resolve({ code: 1, stdout, stderr: `${stderr}${stderr ? "\n" : ""}${error.message}` });
+    });
+    child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+      if (finished) return;
+      finished = true; clearTimeout(timer);
+      const note = overflow ? "output exceeded limit" : timedOut ? `timed out after ${definition.timeoutMs}ms` : signal ? `terminated by ${signal}` : "";
+      resolve({ code: overflow || timedOut ? 1 : (code ?? 1), stdout,
+        stderr: `${stderr}${note ? `${stderr ? "\n" : ""}${note}` : ""}` });
+    });
+    child.stdin.end(payload);
+  });
+}

--- a/lib/host/project-list.ts
+++ b/lib/host/project-list.ts
@@ -2,6 +2,7 @@
 // the walk stays about containment and budgets, and this stays about presentation.
 import path from "path";
 import { boundedGitMeta, packageMeta } from "./project-meta";
+import { projectCapabilities } from "./project-capabilities";
 import { PROJECT_LIMITS, type ProjectRow, type ScanReport } from "./project-containers";
 import { decodeCursor } from "./project-cursor";
 import { listProjectDirs } from "./project-roots";
@@ -30,7 +31,7 @@ export async function listProjects(
   const offset = Math.max(Math.round(options.offset ?? 0), 0);
   const page = matched.slice(offset, offset + limit);
   const projects = await Promise.all(page.map(async ({ container, dir }) => {
-    const [pkg, git] = await Promise.all([packageMeta(dir), boundedGitMeta(dir)]);
+    const [pkg, git, capabilities] = await Promise.all([packageMeta(dir), boundedGitMeta(dir), projectCapabilities(dir)]);
     const name = path.basename(dir);
     return {
       id: `${container.id}/${name}`,
@@ -42,6 +43,7 @@ export async function listProjects(
       ...(pkg.name ? { packageName: pkg.name } : {}),
       ...(pkg.version ? { packageVersion: pkg.version } : {}),
       ...(git.available ? { git: { branch: git.branch, head: git.head?.sha?.slice(0, 12) } } : {}),
+      ...(capabilities ? { capabilities } : {}),
     };
   }));
   const hasMore = offset + page.length < matched.length;

--- a/lib/host/projects.ts
+++ b/lib/host/projects.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "fs";
 import path from "path";
 import { normalizeProjectKey, projectAliasesFor, projectAliasTarget } from "./project-aliases";
 import { boundedGitMeta, fullGitMeta, packageMeta } from "./project-meta";
+import { projectCapabilities } from "./project-capabilities";
 import { homeDir, isUnderRoot } from "./paths";
 import { validateProjectChild, validateProjectDescendant, validateRootHint } from "./project-candidate";
 import { configuredRootPaths, containerById, containerFor, listProjectDirsIn, projectContainers, type ProjectContainer } from "./project-roots";
@@ -142,8 +143,10 @@ export async function resolveProjectHint(hint: string, rootHint?: string): Promi
 }
 
 export async function inspectProject(project: ProjectResolution, options: { includeGitStatus?: boolean } = {}) {
-  return {
-    git: options.includeGitStatus ? await fullGitMeta(project.path) : await boundedGitMeta(project.path),
-    package: await packageMeta(project.path),
-  };
+  const [git, pkg, capabilities] = await Promise.all([
+    options.includeGitStatus ? fullGitMeta(project.path) : boundedGitMeta(project.path),
+    packageMeta(project.path),
+    projectCapabilities(project.path),
+  ]);
+  return { git, package: pkg, ...(capabilities ? { capabilities } : {}) };
 }

--- a/lib/managed-apps/project-ingress-proxy.test.ts
+++ b/lib/managed-apps/project-ingress-proxy.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const TEMPLATE = "{id}.mso.rahmanef.com";
+const ROUTES = JSON.stringify([{
+  app: "hermes", method: "POST", path: "/webhooks/project-example",
+  target: "http://127.0.0.1:8644/webhooks/project-example", auth: "hmac-v2-json",
+}]);
+
+async function loadProxy(ingress = "") {
+  vi.resetModules();
+  vi.stubEnv("NEXT_PUBLIC_MANAGED_APP_HOST_TEMPLATE", TEMPLATE);
+  vi.stubEnv("OS_PROJECT_INGRESS_ROUTES", ingress);
+  return (await import("../../proxy")).proxy;
+}
+
+function req(path: string, signature = "a".repeat(64)) {
+  return new NextRequest(`https://hermes.mso.rahmanef.com${path}`, {
+    method: "POST",
+    headers: {
+      host: "hermes.mso.rahmanef.com",
+      "sec-fetch-site": "cross-site",
+      "content-type": "application/json",
+      "x-webhook-timestamp": String(Math.floor(Date.now() / 1000)),
+      "x-webhook-signature-v2": signature,
+    },
+    body: "{}",
+  });
+}
+const rewriteOf = (res: Response) => res.headers.get("x-middleware-rewrite");
+afterEach(() => vi.unstubAllEnvs());
+
+describe("proxy opt-in project ingress", () => {
+  it("keeps stock MSO closed when no ingress config exists", async () => {
+    const res = await (await loadProxy())(req("/webhooks/project-example"));
+    expect(res.status).toBe(403);
+    expect(rewriteOf(res)).toBeNull();
+  });
+
+  it("relays only the exact operator-declared route", async () => {
+    const proxy = await loadProxy(ROUTES);
+    expect(rewriteOf(await proxy(req("/webhooks/project-example"))))
+      .toBe("http://127.0.0.1:8644/webhooks/project-example");
+    const other = await proxy(req("/webhooks/other"));
+    expect(other.status).toBe(403);
+    expect(rewriteOf(other)).toBeNull();
+  });
+
+  it("rejects malformed auth-shaped traffic before loopback", async () => {
+    const res = await (await loadProxy(ROUTES))(req("/webhooks/project-example", "bad"));
+    expect(res.status).toBe(403);
+    expect(rewriteOf(res)).toBeNull();
+  });
+});

--- a/lib/managed-apps/project-ingress.test.ts
+++ b/lib/managed-apps/project-ingress.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { projectIngressDecision, projectIngressRoutes } from "./project-ingress";
+
+const route = JSON.stringify([{
+  app: "hermes",
+  method: "POST",
+  path: "/webhooks/project-example",
+  target: "http://127.0.0.1:8644/webhooks/project-example",
+  auth: "hmac-v2-json",
+  maxBodyBytes: 262144,
+}]);
+
+function request(path: string, headers: Record<string, string> = {}) {
+  return new Request(`https://hermes.mso.example${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-webhook-timestamp": String(Math.floor(Date.now() / 1000)),
+      "x-webhook-signature-v2": "a".repeat(64),
+      ...headers,
+    },
+    body: "{}",
+  });
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("opt-in project ingress", () => {
+  it("does nothing by default", () => {
+    vi.stubEnv("OS_PROJECT_INGRESS_ROUTES", "");
+    expect(projectIngressRoutes()).toEqual([]);
+    expect(projectIngressDecision(request("/webhooks/project-example"), "hermes", "/webhooks/project-example")).toEqual({ matched: false });
+  });
+
+  it("matches only an explicitly configured exact app/method/path", () => {
+    const decision = projectIngressDecision(request("/webhooks/project-example"), "hermes", "/webhooks/project-example", route);
+    expect(decision).toEqual({ matched: true, target: "http://127.0.0.1:8644/webhooks/project-example" });
+    expect(projectIngressDecision(request("/webhooks/other"), "hermes", "/webhooks/other", route)).toEqual({ matched: false });
+    expect(projectIngressDecision(request("/webhooks/project-example"), "openclaw", "/webhooks/project-example", route)).toEqual({ matched: false });
+  });
+
+  it("rejects stale/malformed auth-shaped traffic before loopback", () => {
+    expect(projectIngressDecision(request("/webhooks/project-example", { "x-webhook-signature-v2": "bad" }), "hermes", "/webhooks/project-example", route)).toEqual({ matched: true });
+    expect(projectIngressDecision(request("/webhooks/project-example", { "x-webhook-timestamp": String(Math.floor(Date.now() / 1000) - 301) }), "hermes", "/webhooks/project-example", route)).toEqual({ matched: true });
+  });
+
+  it("fails closed on off-box, wildcard, duplicate or malformed config", () => {
+    for (const raw of [
+      JSON.stringify([{ app: "hermes", method: "POST", path: "/x", target: "https://evil.example/x", auth: "hmac-v2-json" }]),
+      JSON.stringify([{ app: "hermes", method: "POST", path: "/webhooks/*", target: "http://127.0.0.1:8644/x", auth: "hmac-v2-json" }]),
+      JSON.stringify([
+        { app: "hermes", method: "POST", path: "/x", target: "http://127.0.0.1:8644/x", auth: "hmac-v2-json" },
+        { app: "hermes", method: "POST", path: "/x", target: "http://127.0.0.1:8645/x", auth: "hmac-v2-json" },
+      ]),
+      "not-json",
+    ]) expect(projectIngressRoutes(raw)).toEqual([]);
+  });
+});

--- a/lib/managed-apps/project-ingress.ts
+++ b/lib/managed-apps/project-ingress.ts
@@ -1,0 +1,86 @@
+// Edge-safe, opt-in machine ingress for project integrations. Default = empty,
+// so stock MSO exposes no public managed-app POST lane. A deployment may declare
+// exact app/method/path -> LOOPBACK routes with OS_PROJECT_INGRESS_ROUTES.
+//
+// MSO only performs a cheap HMAC-V2-shaped prefilter. The loopback service remains
+// the cryptographic authority because MSO intentionally does not receive its secret.
+export type ProjectIngressRoute = {
+  app: string;
+  method: "POST";
+  path: string;
+  target: string;
+  auth: "hmac-v2-json";
+  maxBodyBytes: number;
+};
+
+const MAX_ROUTES = 8;
+const DEFAULT_BODY_LIMIT = 256 * 1024;
+const MAX_BODY_LIMIT = 1024 * 1024;
+const APP_RE = /^[a-z0-9][a-z0-9-]{0,31}$/;
+const PATH_RE = /^\/[a-zA-Z0-9._~!$&'()+,;=:@\/-]{1,180}$/;
+const LOOPBACK = new Set(["127.0.0.1", "localhost", "::1"]);
+
+function validTarget(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "http:" || !LOOPBACK.has(url.hostname) || !url.port || url.username || url.password || url.search || url.hash) return null;
+    const port = Number(url.port);
+    if (!Number.isInteger(port) || port < 1 || port > 65535 || !PATH_RE.test(url.pathname) || url.pathname.includes("..")) return null;
+    return url.toString();
+  } catch { return null; }
+}
+
+export function projectIngressRoutes(raw = process.env.OS_PROJECT_INGRESS_ROUTES ?? ""): ProjectIngressRoute[] {
+  if (!raw.trim()) return [];
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { return []; }
+  if (!Array.isArray(parsed) || parsed.length > MAX_ROUTES) return [];
+  const out: ProjectIngressRoute[] = [];
+  const keys = new Set<string>();
+  for (const row of parsed) {
+    if (!row || typeof row !== "object" || Array.isArray(row)) return [];
+    const r = row as Record<string, unknown>;
+    const app = typeof r.app === "string" ? r.app : "";
+    const method = r.method === "POST" ? "POST" : null;
+    const requestPath = typeof r.path === "string" ? r.path : "";
+    const target = validTarget(r.target);
+    const auth = r.auth === "hmac-v2-json" ? "hmac-v2-json" : null;
+    const maxBodyBytes = r.maxBodyBytes === undefined ? DEFAULT_BODY_LIMIT : Number(r.maxBodyBytes);
+    if (!APP_RE.test(app) || !method || !PATH_RE.test(requestPath) || requestPath.includes("..") || !target || !auth) return [];
+    if (!Number.isInteger(maxBodyBytes) || maxBodyBytes < 1024 || maxBodyBytes > MAX_BODY_LIMIT) return [];
+    const key = `${app}:${method}:${requestPath}`;
+    if (keys.has(key)) return [];
+    keys.add(key);
+    out.push({ app, method, path: requestPath, target, auth, maxBodyBytes });
+  }
+  return out;
+}
+
+function plausibleHmacV2Json(request: Request, route: ProjectIngressRoute): boolean {
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.startsWith("application/json")) return false;
+  const seconds = Number(request.headers.get("x-webhook-timestamp") ?? "");
+  if (!Number.isInteger(seconds) || Math.abs(Math.floor(Date.now() / 1000) - seconds) > 300) return false;
+  if (!/^[0-9a-f]{64}$/i.test(request.headers.get("x-webhook-signature-v2") ?? "")) return false;
+  const lengthHeader = request.headers.get("content-length");
+  if (lengthHeader) {
+    const length = Number(lengthHeader);
+    if (!Number.isFinite(length) || length < 0 || length > route.maxBodyBytes) return false;
+  }
+  return true;
+}
+
+export function projectIngressDecision(
+  request: Request,
+  managedApp: string | null,
+  pathname: string,
+  raw = process.env.OS_PROJECT_INGRESS_ROUTES ?? "",
+): { matched: false } | { matched: true; target?: string } {
+  if (!managedApp) return { matched: false };
+  const route = projectIngressRoutes(raw).find((candidate) =>
+    candidate.app === managedApp && candidate.method === request.method && candidate.path === pathname,
+  );
+  if (!route) return { matched: false };
+  return plausibleHmacV2Json(request, route) ? { matched: true, target: route.target } : { matched: true };
+}

--- a/lib/mcp/dispatch.test.ts
+++ b/lib/mcp/dispatch.test.ts
@@ -44,7 +44,7 @@ describe("protocol", () => {
   it("publishes server and toolset metadata so action drift is visible", async () => {
     const r = await dispatch({ id: 1, method: "initialize" }, "exec");
     const result = r.result as { serverInfo: { version: string }; _meta: { toolset: { toolCount: number; hash: string } } };
-    expect(result.serverInfo.version).toBe("1.5.3");
+    expect(result.serverInfo.version).toBe("1.6.0");
     expect(result._meta.toolset.toolCount).toBe(TOOLS.length);
     expect(result._meta.toolset.hash).toMatch(/^[a-f0-9]{16}$/);
   });

--- a/lib/mcp/global-tools.test.ts
+++ b/lib/mcp/global-tools.test.ts
@@ -98,6 +98,13 @@ describe("no per-project or per-agent tool filter exists", () => {
       expect(tool.inputSchema.required ?? [], tool.name).not.toContain("workflow_id");
     }
   });
+
+  it("keeps project function execution in exec while discovery stays read", async () => {
+    expect(await names("read")).toContain("project_capabilities");
+    expect(await names("read")).not.toContain("project_function_call");
+    expect(await names("write")).not.toContain("project_function_call");
+    expect(await names("exec")).toContain("project_function_call");
+  });
 });
 
 describe("image generation is gone from every surface", () => {
@@ -137,6 +144,6 @@ describe("file import survives the image-generation removal", () => {
 describe("global discovery is part of the public catalog", () => {
   it("ships projects_list, skills_list and skills_read at read scope", async () => {
     const read = await names("read");
-    for (const name of ["projects_list", "skills_list", "skills_read", "skills_search"]) expect(read).toContain(name);
+    for (const name of ["projects_list", "project_capabilities", "skills_list", "skills_read", "skills_search"]) expect(read).toContain(name);
   });
 });

--- a/lib/mcp/parity.test.ts
+++ b/lib/mcp/parity.test.ts
@@ -35,6 +35,8 @@ const ALFA_ONLY: Record<string, string> = {
 const MCP_ONLY: Record<string, string> = {
   "screen.capture": "external MCP clients need visual proof of the rendered OS; in-shell Alfa already runs inside that browser UI",
   "projects.list": "an MCP client has no sidebar and no Files window, so it needs an explicit bounded enumeration of every project container; in-shell Alfa reads the same roots through fs.list and the Files app",
+  "project.capabilities": "external harnesses need a stable generic discovery seam for project-owned MCP/functions; Alfa can inspect the same project files through its existing fs/skills tools without changing its cached tool array",
+  "project.function.call": "external MCP clients need one no-shell bridge into project-declared functions; Alfa already has per-call-approved exec.run and must not receive a dynamic per-project tool catalog",
   "fs.upload.file": "external ChatGPT connectors need openai/fileParams to move conversation-generated files onto the VPS; in-shell Alfa already has direct host filesystem access",
   "workflow.start": "the external connector needs an actor-scoped task boundary; Alfa already owns an in-app conversation/run boundary",
   "workflow.cancel": "same actor-scoped boundary; external runs need explicit recovery from an interrupted task",
@@ -102,6 +104,8 @@ describe("MCP rate limits mirror the routes", () => {
       // Global discovery reads: no HTTP route mirrors them, and each one walks
       // every configured container, so they get their own small buckets.
       "projects.list": 30,
+      "projects.capabilities": 60,
+      "projects.function": 60,
       "skills.list": 30,
       "skills.read": 60,
     };

--- a/lib/mcp/project-functions.test.ts
+++ b/lib/mcp/project-functions.test.ts
@@ -1,0 +1,44 @@
+import { afterAll, describe, expect, it, vi } from "vitest";
+vi.mock("server-only", () => ({}));
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+
+const base = await fs.mkdtemp(path.join(os.tmpdir(), "mso-mcp-project-fn-"));
+const project = path.join(base, "widget");
+await fs.mkdir(path.join(project, ".mso"), { recursive: true });
+const code = "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>process.stdout.write(s))";
+await fs.writeFile(path.join(project, ".mso/functions.json"), JSON.stringify({
+  version: 1,
+  functions: [{
+    name: "echo_json", description: "Echo input JSON.",
+    inputSchema: { type: "object", properties: { value: { type: "string" } }, required: ["value"] },
+    command: [process.execPath, "-e", code],
+  }],
+}));
+const previous = process.env.OS_FS_READ_ROOTS;
+process.env.OS_FS_READ_ROOTS = base;
+const { TOOLS_BY_NAME } = await import("./tools");
+
+afterAll(async () => {
+  if (previous === undefined) delete process.env.OS_FS_READ_ROOTS;
+  else process.env.OS_FS_READ_ROOTS = previous;
+  await fs.rm(base, { recursive: true, force: true });
+});
+
+describe("project function MCP bridge", () => {
+  it("is one stable exec-scope tool, not a dynamic tool per project function", () => {
+    const tool = TOOLS_BY_NAME.get("project_function_call");
+    expect(tool?.scope).toBe("exec");
+    expect(TOOLS_BY_NAME.has("echo_json")).toBe(false);
+  });
+
+  it("runs an opted-in project function with exact JSON stdin", async () => {
+    const result = await TOOLS_BY_NAME.get("project_function_call")!.run({
+      project,
+      name: "echo_json",
+      input: { value: "hello; $(not-a-shell)" },
+    }, { scope: "exec" });
+    expect(result).toEqual({ code: 0, stdout: JSON.stringify({ value: "hello; $(not-a-shell)" }), stderr: "" });
+  });
+});

--- a/lib/mcp/tools-discovery.test.ts
+++ b/lib/mcp/tools-discovery.test.ts
@@ -25,6 +25,16 @@ async function skill(dir: string, name: string, description: string, body = "ste
 
 await skill(path.join(widgetA, ".claude/skills"), "widget-deploy", "Ship the widget service from root A.");
 await fs.writeFile(path.join(widgetA, "package.json"), JSON.stringify({ name: "widget", version: "0.1.0" }));
+await fs.writeFile(path.join(widgetA, ".mcp.json"), JSON.stringify({ mcpServers: { local: { command: "ignored-secret-free-fixture" } } }));
+await fs.mkdir(path.join(widgetA, ".mso"), { recursive: true });
+await fs.writeFile(path.join(widgetA, ".mso/functions.json"), JSON.stringify({
+  version: 1,
+  functions: [{
+    name: "widget_status", description: "Read widget status.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    command: [process.execPath, "-e", "process.stdout.write('ok')"],
+  }],
+}));
 await skill(path.join(widgetB, ".claude/skills"), "widget-deploy", "Ship the widget service from root B.");
 // A project whose skills ROOT escapes the project via symlink: the SKILL.md is a real
 // regular file, so it is discoverable — but containment fails, so it is untrusted and
@@ -76,12 +86,14 @@ describe("projects_list", () => {
 
   it("enumerates every project across BOTH containers, keeping same-named ones distinct", async () => {
     const result = await run("projects_list") as {
-      total: number; scan: Scan; projects: Array<{ id: string; name: string; rootId: string; packageName?: string }>;
+      total: number; scan: Scan; projects: Array<{ id: string; name: string; rootId: string; packageName?: string; capabilities?: Record<string, unknown> }>;
     };
     expect(result.projects.map((p) => p.name)).toEqual(["gadget", "widget", "widget"]);
     expect(new Set(result.projects.map((p) => p.id)).size).toBe(3);
     expect(result.total).toBe(3);
-    expect(result.projects.find((p) => p.packageName === "widget")).toBeDefined();
+    const optedIn = result.projects.find((p) => p.packageName === "widget");
+    expect(optedIn).toBeDefined();
+    expect(optedIn?.capabilities).toMatchObject({ mcp: { config: ".mcp.json" }, functions: { valid: true, count: 1 } });
   });
 
   it("reports a truthful scan report on a complete enumeration", async () => {
@@ -94,6 +106,17 @@ describe("projects_list", () => {
     const result = await run("projects_list", { query: "wid", limit: 1 }) as { total: number; limit: number; projects: Array<{ name: string }> };
     expect(result).toMatchObject({ total: 2, limit: 1 });
     expect(result.projects.map((p) => p.name)).toEqual(["widget"]);
+  });
+});
+
+describe("project_capabilities", () => {
+  it("returns only public capability metadata for one exact project", async () => {
+    const result = await run("project_capabilities", { project: await projectId(widgetA) }) as {
+      capabilities: { mcp?: { config: string }; functions?: { valid: boolean; tools?: Array<{ name: string }> } };
+    };
+    expect(result.capabilities.mcp).toEqual({ config: ".mcp.json" });
+    expect(result.capabilities.functions).toMatchObject({ valid: true, tools: [{ name: "widget_status" }] });
+    expect(JSON.stringify(result)).not.toContain(process.execPath);
   });
 });
 

--- a/lib/mcp/tools-discovery.ts
+++ b/lib/mcp/tools-discovery.ts
@@ -1,4 +1,4 @@
-import { listProjects, PROJECT_LIMITS } from "@/lib/host";
+import { listProjects, projectCapabilities, resolveProjectHint, PROJECT_LIMITS } from "@/lib/host";
 import { catalogSkillsDetailed, resolveSkill, readSkillFile, skillIsExecutableByDefault, SKILL_SCAN_LIMITS } from "@/lib/skills/catalog";
 import { type McpTool, str, opt, S, READ_ONLY } from "./tool-kit";
 
@@ -22,10 +22,29 @@ const page = (a: Record<string, unknown>, max: number, fallback: number) => ({
 
 export const DISCOVERY_TOOLS: McpTool[] = [
   {
+    name: "project_capabilities",
+    description:
+      "Inspect ONE validated project for opt-in automation capabilities without exposing secrets. " +
+      "Reports whether a regular .mcp.json exists and, when present, the public name/description/schema metadata from .mso/functions.json. " +
+      "Project function commands are deliberately withheld; execution is only through project_function_call at exec scope. " +
+      "Nothing is enabled globally: projects without these files return an empty capability object.",
+    scope: "read",
+    annotations: READ_ONLY,
+    limit: { key: "projects.capabilities", max: 60, windowMs: 60_000 },
+    inputSchema: S({
+      project: { type: "string", description: "Exact project id from projects_list, absolute path, name or alias." },
+    }, ["project"]),
+    run: async (a) => {
+      const project = await resolveProjectHint(str(a, "project"));
+      if (!project) throw new Error(`project not found: ${String(a.project)}`);
+      return { project: { id: project.id, name: project.name, path: project.path }, capabilities: (await projectCapabilities(project.path)) ?? {} };
+    },
+  },
+  {
     name: "projects_list",
     description:
       "Enumerate the owner's projects across EVERY configured project container (each OS_FS_READ_ROOTS entry and its projects/ subdirectory), not just ~/projects. " +
-      "Returns a globally unique id (<rootId>/<name>, so two roots may hold a project of the same name), absolute path, its container root, package name/version and bounded Git branch/head read straight off .git with no shell. " +
+      "Returns a globally unique id (<rootId>/<name>, so two roots may hold a project of the same name), absolute path, its container root, package name/version, bounded Git branch/head, and opt-in MCP/function capability summary. " +
       "USE THIS FIRST when the user names a project you have not located — it is one call, needs no shell scope, and its id or path is the input to workflow_start. " +
       "Hidden directories, symlinks, credential paths and directories not owned by the MSO user are excluded. " +
       "ALWAYS check `scan.truncated`: when true the listing is incomplete and `scan.truncationReasons` says which cap was hit — do not report that a project is absent from a truncated scan. " +

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -1,4 +1,4 @@
-import { writeFileGuarded, makeDir, remove, move, copy, runCommand } from "@/lib/host";
+import { writeFileGuarded, makeDir, remove, move, copy, runCommand, resolveProjectHint, runProjectFunction } from "@/lib/host";
 import { type McpTool, str, opt, S, PATH_P } from "./tool-kit";
 import { importOpenAiProvidedFile } from "./openai-file-upload";
 import { READ_TOOLS } from "./tools-read";
@@ -106,6 +106,34 @@ const MUTATE_TOOLS: McpTool[] = [
     run: async (a) => { await remove(str(a, "path")); return { ok: true, path: a.path }; },
   },
 
+  {
+    name: "project_function_call",
+    limit: { key: "projects.function", max: 60, windowMs: 60_000 },
+    audit: {
+      action: "exec.run" as const,
+      targetArg: "project",
+      outcome: (r) => {
+        const { code } = r as { code: number };
+        return { ok: code === 0, action: "exec.run", detail: `project function exit ${code}` };
+      },
+    },
+    description:
+      "Execute ONE function explicitly declared by a validated project's .mso/functions.json. " +
+      "This is project code execution and therefore requires exec scope. The manifest supplies fixed argv; model/user input is passed only as JSON on stdin and is NEVER interpolated into a shell command. " +
+      "Call project_capabilities first for function names and schemas. Projects without an opt-in manifest expose nothing.",
+    scope: "exec",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: S({
+      project: { type: "string", description: "Exact project id from projects_list, absolute path, name or alias." },
+      name: { type: "string", description: "Function name returned by project_capabilities." },
+      input: { type: "object", description: "JSON object passed to the project function on stdin.", additionalProperties: true },
+    }, ["project", "name", "input"]),
+    run: async (a) => {
+      const project = await resolveProjectHint(str(a, "project"));
+      if (!project) throw new Error(`project not found: ${String(a.project)}`);
+      return runProjectFunction(project.path, str(a, "name"), a.input);
+    },
+  },
   {
     name: "exec_run",
     limit: { key: "exec", max: 60, windowMs: 60_000 },

--- a/lib/mcp/toolset.ts
+++ b/lib/mcp/toolset.ts
@@ -2,9 +2,9 @@ import { createHash } from "crypto";
 import type { Scope } from "./scope";
 import type { McpTool } from "./tool-kit";
 
-export const MCP_SERVER_VERSION = "1.5.3";
-export const MCP_TOOLSET_VERSION = "2026.08.20.6";
-export const MCP_TOOLSET_CHANGED_AT = "2026-08-20T16:40:00Z";
+export const MCP_SERVER_VERSION = "1.6.0";
+export const MCP_TOOLSET_VERSION = "2026.08.21.1";
+export const MCP_TOOLSET_CHANGED_AT = "2026-08-21T13:45:00Z";
 
 export type McpToolsetInfo = {
   serverVersion: string;

--- a/lib/skills/memory.ts
+++ b/lib/skills/memory.ts
@@ -207,6 +207,8 @@ const SAFE_TOOL_ARGS: Record<string, readonly string[]> = {
   fs_usage: ["path"],
   apps_logs: ["id"],
   projects_list: ["query", "limit", "offset"],
+  project_capabilities: ["project"],
+  project_function_call: ["project", "name"],
   skills_list: ["project", "trust", "limit", "offset"],
   skills_read: ["name"],
   screen_capture: ["shell", "width", "height"],

--- a/proxy.ts
+++ b/proxy.ts
@@ -24,6 +24,7 @@ import {
 } from "@/lib/managed-apps/origin";
 import { proxyPrefix, upstreamSocketHeaders } from "@/lib/managed-apps/proxy-headers";
 import { getManagedAppDefinition } from "@/lib/managed-apps/catalog";
+import { projectIngressDecision } from "@/lib/managed-apps/project-ingress";
 import { verifySession } from "@/lib/auth/session";
 import { isApproved } from "@/lib/auth/device-store";
 import { IS_DEMO } from "@/lib/demo";
@@ -149,6 +150,17 @@ export async function proxy(request: NextRequest) {
   // lie (claiming an app host while on the cockpit) only restricts the request.
   const host = request.headers.get("host") ?? request.nextUrl.host;
   const managedApp = managedAppIdForHost(host);
+
+  // Optional project integrations may expose ONE exact machine-to-machine POST
+  // lane on a managed-app host. Stock MSO has no routes because
+  // OS_PROJECT_INGRESS_ROUTES defaults to empty. The route config is fixed by the
+  // operator, targets loopback only, and the upstream still verifies the real
+  // HMAC secret; this edge check only rejects obvious public garbage before CSRF.
+  const ingress = projectIngressDecision(request, managedApp, pathname);
+  if (ingress.matched) {
+    if (!ingress.target) return blocked();
+    return NextResponse.rewrite(new URL(ingress.target));
+  }
 
   // A host inside the app namespace that is NOT an app (a new `X.mso.rahmanef.com`
   // record, or a `*.os` wildcard) must not serve the cockpit: the session cookie is

--- a/scripts/e2e/shell.mjs
+++ b/scripts/e2e/shell.mjs
@@ -77,13 +77,13 @@ const IGNORE = [
   /openverse|unsplash/i,
 ];
 
-async function session(browser, { width, height, label }) {
+async function session(browser, { width, height, label, touch = width < 768, expectedSurface = width < 768 ? "mobile" : "desktop" }) {
   console.log(`\n▶ ${label} (${width}×${height})`);
   const ctx = await browser.newContext({
     viewport: { width, height },
     deviceScaleFactor: 2,
-    hasTouch: width < 768,
-    isMobile: width < 768,
+    hasTouch: touch,
+    isMobile: touch,
   });
   const errors = [];
   ctx.on("console", (m) => {
@@ -140,8 +140,8 @@ async function session(browser, { width, height, label }) {
   check(me?.authenticated === true, `really signed in (authenticated=${me?.authenticated})`);
   if (!me?.authenticated) fail("everything below this line is testing MOCK data — fix auth first");
   check(
-    width < 768 ? ["ios", "android"].includes(shell) : ["macos", "windows", "dashboard"].includes(shell),
-    `${shell} is the right shell for this viewport`,
+    expectedSurface === "mobile" ? ["ios", "android"].includes(shell) : ["macos", "windows", "dashboard"].includes(shell),
+    `${shell} is the right ${expectedSurface} shell for this viewport`,
   );
 
   // ── no horizontal overflow. A shell that scrolls sideways is broken on a phone
@@ -160,7 +160,11 @@ async function session(browser, { width, height, label }) {
   // pointer, and the iOS home paginates so half the grid is off-screen. A launcher
   // that cannot be clicked is a real finding, but it is a DIFFERENT test from "does
   // this app render", and conflating them made both unreliable.
-  for (const slug of ["files", "monitor", "settings", "code", "terminal"]) {
+  const nativeSlugs = [
+    "files", "browser", "code", "terminal", "claude", "studio", "reel", "viewer",
+    "store", "create", "monitor", "assistant", "links", "docs", "settings",
+  ];
+  for (const slug of nativeSlugs) {
     await page.goto(`${BASE}/${slug}`, { waitUntil: "domcontentloaded" });
     await page.waitForTimeout(1200);
     // Desktop puts the app in a [data-window]; iOS/Android render it full-screen in
@@ -191,13 +195,26 @@ async function session(browser, { width, height, label }) {
   check(realErrors.length === 0, `zero console errors${realErrors.length ? ` — first: ${realErrors[0].slice(0, 160)}` : ""}`);
   for (const e of realErrors.slice(0, 5)) console.log(`      · ${e.slice(0, 200)}`);
 
+  // Managed-app routes are cross-origin embeds in production. On a loopback E2E
+  // origin their own frame-ancestors/session policy correctly rejects the iframe,
+  // so exercise host routing/rendering here without treating that origin mismatch
+  // as an MSO host-network failure. Their own runtime has separate managed-app tests.
+  for (const slug of ["hermes", "openclaw"]) {
+    await page.goto(`${BASE}/${slug}`, { waitUntil: "domcontentloaded" });
+    await page.waitForTimeout(1200);
+    check(page.url().endsWith(`/${slug}`), `/${slug} managed-app deep-link kept the URL`);
+    if (width >= 768) check((await page.locator("[data-window]").count()) > 0, `/${slug} managed-app opened a window`);
+    check((await page.locator(".animate-spin").count()) === 0, `/${slug} managed-app host rendered without a stuck spinner`);
+  }
+
   await ctx.close();
 }
 
 const browser = await chromium.launch({ headless: HEADLESS });
 try {
   await session(browser, { width: 1280, height: 800, label: "desktop" });
-  await session(browser, { width: 390, height: 844, label: "mobile" });
+  await session(browser, { width: 390, height: 844, label: "mobile portrait" });
+  await session(browser, { width: 844, height: 390, label: "phone landscape → desktop", touch: true, expectedSurface: "desktop" });
 } finally {
   await browser.close();
 }

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -20,6 +20,16 @@ set -e
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+# Git exports repository-local environment variables to hooks (GIT_DIR,
+# GIT_WORK_TREE, GIT_INDEX_FILE, object directories, and friends). The test suite
+# intentionally creates temporary Git repositories; if those variables leak into a
+# child `git init`, Git can operate on THIS repository instead of the fixture.
+# Locate the root first, then clear only Git's documented local env so every child
+# Git process discovers the repository from its own cwd.
+while IFS= read -r git_local_var; do
+  [ -n "$git_local_var" ] && unset "$git_local_var"
+done < <(git rev-parse --local-env-vars 2>/dev/null || true)
+
 if [ "${1-}" = "--install" ]; then
   HOOK="$ROOT/.git/hooks/pre-push"
   mkdir -p "$(dirname "$HOOK")"


### PR DESCRIPTION
## Why

Keep stock MSO generic. Project-specific MCP/function integrations should be opt-in project data, not hard-coded product behavior or a per-project dynamic AI tool array.

## What changed

- Adds read-scope `project_capabilities`.
  - detects a regular `.mcp.json` but never returns its contents/secrets;
  - reads public function metadata from `.mso/functions.json`.
- Adds exec-scope `project_function_call`.
  - one stable MSO tool for every project;
  - project function names remain data, preserving the global/cached tool catalog;
  - manifest supplies fixed argv;
  - caller/model JSON is passed only on stdin, with `shell:false` and MSO/provider credentials scrubbed;
  - validates required fields, `additionalProperties`, primitive types and enums before spawning.
- `projects_list` and `workflow_start` repository inspection now report opt-in project capability metadata.
- Adds generic `OS_PROJECT_INGRESS_ROUTES` for exact managed-app machine ingress.
  - default is empty: stock MSO behavior is unchanged;
  - max 8 exact POST routes;
  - loopback-only targets;
  - HMAC-V2-shaped JSON prefilter before bypassing app-host CSRF;
  - destination app remains the actual cryptographic verifier.
- No AntiNRML/project/business name or webhook path is compiled into MSO.
- Toolset: `1.6.0` / `2026.08.21.1`, 28 tools (15 read, 10 write, 3 exec).

### Project opt-in example

```json
{
  "version": 1,
  "functions": [{
    "name": "asset_status",
    "description": "Read the project's asset status.",
    "inputSchema": {
      "type": "object",
      "properties": { "id": { "type": "string" } },
      "required": ["id"],
      "additionalProperties": false
    },
    "command": ["bun", "run", "project:call", "--", "asset_status"]
  }]
}
```

## Security / architecture

- No dynamic per-project model tool list.
- No implicit execution merely because `.mcp.json` exists.
- `.mso` symlinks and symlinked manifests fail closed.
- Manifest/file reads are size-bounded before bytes are read.
- `project_function_call` is always exec-scope, even for logically read-only project functions.
- Caller values cannot become shell syntax because they are never interpolated into argv.
- Public ingress is completely disabled unless the operator explicitly configures it.

## Verification

- `bun run verify`: pass
- 167 test files passed; 1535 tests passed; 1 expected failure fixture; 7 skipped
- typecheck: pass
- lint: 0 errors; 1 pre-existing max-lines warning in `lib/mcp/dispatch.test.ts`
- coverage/check-cycles/check-skill-flows/security audit: pass
- value cycles: 0
- throwaway production build: pass
- no AntiNRML-specific hardcode remains in the PR diff
