### PR TITLE
fix(settings): adopt native iOS hierarchy

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -396,6 +396,50 @@ body {
   transform-origin: bottom;
 }
 
+
+/* ── iOS System Settings app ───────────────────────────────────────────────
+   System Settings owns its iOS navigation chrome, matching the native hierarchy:
+   large-title/search root → grouped inset lists → blue Settings back on detail.
+   These selectors are fully iOS + Settings-slot scoped; Android/desktop shells
+   keep their existing layouts. */
+[data-shell="ios"] [data-slot="ios-settings-root"],
+[data-shell="ios"] [data-slot="ios-settings-detail"] {
+  font-family: var(--shell-font);
+  background: var(--grouped);
+}
+[data-shell="ios"] [data-slot="ios-settings-root"] [data-slot="settings-card"],
+[data-shell="ios"] [data-slot="ios-settings-detail"] [data-slot="settings-card"] {
+  border: 0;
+  border-radius: 16px;
+  box-shadow: none;
+}
+[data-shell="ios"] [data-slot="ios-settings-detail"] [data-slot="settings-section-heading"] {
+  gap: 0;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+[data-shell="ios"] [data-slot="ios-settings-detail"] [data-slot="settings-section-icon"] {
+  display: none;
+}
+[data-shell="ios"] [data-slot="ios-settings-detail"] [data-slot="settings-section-title"] {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  color: var(--text-dim);
+}
+[data-shell="ios"] [data-slot="ios-settings-detail"] [data-slot="settings-row"] {
+  min-height: 50px;
+}
+[data-shell="ios"] [data-slot="ios-settings-detail"] [data-slot="settings-row"]:has([role="switch"]) {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+[data-shell="ios"] [data-slot="ios-settings-detail"] [data-slot="settings-row"]:has([role="switch"]) > div:last-child {
+  width: auto;
+  flex-shrink: 0;
+}
+
 /* ── Touch-target a11y (HIG 44px / Material 48dp) ──────────────────────────
    The app root is 14px, so rem-based control heights fall short of 44px
    (h-8 = 28px, h-9 = 31.5px). Lift form controls + menu rows on ANY coarse

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `settings` adopt native iOS hierarchy
 - `icons` align mobile platform artwork
 - `responsive` harden mobile and landscape layouts
 - `git` isolate push-gate test repositories

--- a/frontend/slices/appshell/components/mobile-shell.tsx
+++ b/frontend/slices/appshell/components/mobile-shell.tsx
@@ -204,6 +204,7 @@ export function MobileShell() {
               the app scrolls (onScrollCapture on <main> catches the app's own inner
               scroll container generically). Title stays put — mso apps carry no
               in-content large title to fade in. */}
+          {!activeApp.ownsMobileNavigation && (
           <header
             className={cn(
               "shrink-0 border-b transition-[background-color,border-color] duration-200",
@@ -238,6 +239,7 @@ export function MobileShell() {
               </Button>
             </div>
           </header>
+          )}
           {/* The home-indicator overlays the content edge-to-edge (real-iOS), so
               --sai-bottom INSIDE the app pane must clear its 34px band — every app
               already pads with var(--sai-bottom), so setting the var here clears the

--- a/frontend/slices/appshell/lib/types.ts
+++ b/frontend/slices/appshell/lib/types.ts
@@ -91,6 +91,11 @@ export type AppDescriptor = {
   /** Pinned to the mobile dock / quick-shortcut set (consumer manifest decides
    *  — the generic shell never hardcodes project app ids). */
   pinned?: boolean;
+  /** Let the iOS fullscreen app own its navigation bar instead of receiving the
+   *  shell's generic app-icon/title/Done header. Used by apps whose native UI
+   *  already has a complete iOS navigation stack (System Settings). Android has
+   *  separate shell chrome and is intentionally unaffected. */
+  ownsMobileNavigation?: boolean;
   /** Allow several windows at once (e.g. Files); default = single instance. */
   multi?: boolean;
 

--- a/frontend/slices/os-settings/app.tsx
+++ b/frontend/slices/os-settings/app.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/features/os-shell";
 import { SettingsTabs, SettingsSidebar, type SectionId } from "./components/nav";
 import { SectionDetail, SectionList } from "./components/sections";
+import { IosSettings } from "./components/ios-settings";
 
 // Default export so os-shell can lazy-load it as a window app.
 export default function OsSettings() {
@@ -68,8 +69,18 @@ export default function OsSettings() {
   const layout: "stack" | "sidebar" | "tabs" =
     surface === "mobile" ? "stack" : shellId === "macos" ? "sidebar" : "tabs";
 
-  // Mobile (iOS/Android): MasterDetail drill-down. The mobile shell chrome already
-  // paints the "Settings" app title above this, so no in-pane large-title here.
+  // iOS Settings owns its full native navigation stack: the generic iOS app
+  // header is disabled by the app descriptor, so the root can use Apple's
+  // large-title/search hierarchy and detail pages can own the Settings back row.
+  if (surface === "mobile" && shellId === "ios") {
+    return (
+      <AppFrame safeArea={false} bodyClassName="overflow-hidden">
+        <IosSettings active={active} onSelect={setActive} onBack={() => setActive(null)} />
+      </AppFrame>
+    );
+  }
+
+  // Android keeps the shared MasterDetail drill-down and Android shell chrome.
   if (layout === "stack") {
     return (
       <AppFrame>

--- a/frontend/slices/os-settings/components/ios-settings.tsx
+++ b/frontend/slices/os-settings/components/ios-settings.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { SECTIONS, type SectionId } from "./nav";
+import { SettingsSectionBody } from "./sections";
+
+// iOS System Settings owns its navigation chrome instead of inheriting the
+// generic fullscreen-app header. This keeps the hierarchy native: large title +
+// Search at the root, then a blue "Settings" back affordance on detail pages.
+export function IosSettings({
+  active,
+  onSelect,
+  onBack,
+}: {
+  active: SectionId | null;
+  onSelect: (id: SectionId) => void;
+  onBack: () => void;
+}) {
+  return active ? (
+    <IosSettingsDetail id={active} onBack={onBack} />
+  ) : (
+    <IosSettingsIndex onSelect={onSelect} />
+  );
+}
+
+function IosSettingsIndex({ onSelect }: { onSelect: (id: SectionId) => void }) {
+  const [query, setQuery] = useState("");
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return q
+      ? SECTIONS.filter((s) => `${s.label} ${s.blurb}`.toLowerCase().includes(q))
+      : SECTIONS;
+  }, [query]);
+  const groups = filtered.reduce<(typeof SECTIONS)[number][][]>((acc, section) => {
+    const last = acc[acc.length - 1];
+    if (last && last[0]?.group === section.group) last.push(section);
+    else acc.push([section]);
+    return acc;
+  }, []);
+
+  return (
+    <div data-slot="ios-settings-root" className="h-full overflow-y-auto bg-[var(--grouped)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <div className="mx-auto w-full max-w-2xl px-4 pb-[calc(var(--sai-bottom,0px)+1.5rem)] pt-[calc(var(--sai-top,0px)+2.5rem)]">
+        <h1 className="px-0.5 text-[34px] font-bold leading-[1.05] tracking-[-0.025em] text-foreground">Settings</h1>
+
+        <label className="mt-5 flex h-[38px] items-center gap-2 rounded-[11px] bg-[var(--fill)] px-3 text-muted-foreground">
+          <Search className="size-[19px] shrink-0" aria-hidden />
+          <span className="sr-only">Search settings</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search"
+            autoComplete="off"
+            className="h-full min-w-0 flex-1 border-0 bg-transparent p-0 !text-[17px] text-foreground outline-none placeholder:text-muted-foreground focus-visible:outline-none"
+          />
+        </label>
+
+        <nav aria-label="Settings sections" className="mt-5 space-y-6">
+          {groups.map((group) => (
+            <div key={group[0]?.group} data-slot="settings-card" className="overflow-hidden rounded-[16px] bg-card">
+              {group.map((section) => {
+                const Icon = section.icon;
+                return (
+                  <button
+                    key={section.id}
+                    type="button"
+                    data-slot="settings-index-row"
+                    onClick={() => onSelect(section.id)}
+                    className={cn(
+                      "relative flex min-h-[52px] w-full items-center gap-3 px-4 py-2 text-left transition-colors",
+                      "after:absolute after:inset-x-0 after:bottom-0 after:left-[60px] after:h-px after:bg-[var(--sep)] last:after:hidden",
+                      "active:bg-[var(--fill)]",
+                    )}
+                  >
+                    <span
+                      className="grid size-[31px] shrink-0 place-items-center rounded-[8px] shadow-[0_1px_2px_rgba(0,0,0,0.22)]"
+                      style={{ background: section.color }}
+                    >
+                      <Icon className="size-[18px] text-white" aria-hidden />
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-[17px] font-normal leading-tight text-foreground">{section.label}</span>
+                    <ChevronRight className="size-[17px] shrink-0 text-muted-foreground/55" aria-hidden />
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </nav>
+
+        {filtered.length === 0 && (
+          <p className="py-16 text-center text-[15px] text-muted-foreground">No settings found.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function IosSettingsDetail({ id, onBack }: { id: SectionId; onBack: () => void }) {
+  const meta = SECTIONS.find((s) => s.id === id)!;
+  // Appearance/Theme already begin with strong visual controls, matching Apple's
+  // Display & Brightness pattern. The other categories use the General/Wi‑Fi
+  // style identity card before their grouped controls.
+  const showHero = id !== "appearance" && id !== "theme";
+  const Icon = meta.icon;
+
+  return (
+    <div data-slot="ios-settings-detail" className="flex h-full min-h-0 flex-col bg-[var(--grouped)]">
+      <header className="shrink-0 bg-[var(--grouped)] pt-[var(--sai-top,0px)]">
+        <div className="flex h-[48px] min-w-0 items-center px-1.5">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onBack}
+            className="h-[44px] shrink-0 gap-0 px-1 text-[17px] font-normal text-info hover:bg-transparent hover:text-info"
+          >
+            <ChevronLeft className="size-[25px]" aria-hidden />
+            Settings
+          </Button>
+          {!showHero && (
+            <h1 className="ml-2 min-w-0 truncate text-[17px] font-semibold tracking-[-0.01em] text-foreground">{meta.label}</h1>
+          )}
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="mx-auto w-full max-w-2xl space-y-6 px-4 pb-[calc(var(--sai-bottom,0px)+1.5rem)] pt-4">
+          {showHero && (
+            <section data-slot="ios-settings-hero" className="rounded-[18px] bg-card px-5 py-6 text-center">
+              <span
+                className="mx-auto grid size-[64px] place-items-center rounded-[16px] shadow-[0_2px_5px_rgba(0,0,0,0.22)]"
+                style={{ background: meta.color }}
+              >
+                <Icon className="size-9 text-white" aria-hidden />
+              </span>
+              <h1 className="mt-3 text-[24px] font-bold leading-tight tracking-[-0.02em] text-foreground">{meta.label}</h1>
+              <p className="mx-auto mt-2 max-w-[32rem] text-[16px] leading-[1.35] text-foreground/90">{meta.blurb}</p>
+            </section>
+          )}
+
+          <SettingsSectionBody id={id} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/slices/os-settings/components/sections.tsx
+++ b/frontend/slices/os-settings/components/sections.tsx
@@ -22,7 +22,7 @@ import { AboutSection } from "./about-section";
 // The section content — one functional panel per SectionId, shared verbatim by
 // every shell's Settings layout (the per-shell seam only swaps the navigation
 // chrome around these, never the bodies).
-function SectionBody({ id }: { id: SectionId }) {
+export function SettingsSectionBody({ id }: { id: SectionId }) {
   switch (id) {
     case "appearance":
       return <AppearanceSection />;
@@ -88,18 +88,15 @@ export function SectionDetail({ id }: { id: SectionId }) {
               <p className="text-xs text-muted-foreground">{meta.blurb}</p>
             </header>
           ))}
-        <SectionBody id={id} />
+        <SettingsSectionBody id={id} />
       </div>
     </ScrollArea>
   );
 }
 
-// Mobile section index — Apple iOS System Settings: colored icon tiles in grouped
-// rounded cards, single-line rows with a trailing chevron, hairline separators
-// inset to the label. Tapping a row drills the MasterDetail into the section
-// content; the back arrow returns here. No large title in-pane — the mobile
-// app-chrome header already paints "Settings" (avoids a double title); no search
-// pill either (ten sections don't warrant one, and a dead field is a fake affordance).
+// Shared mobile fallback section index. Android uses this MasterDetail list; iOS
+// owns a richer native root in ios-settings.tsx (large title + functional Search),
+// so this stays deliberately generic rather than duplicating the iOS hierarchy.
 export function SectionList({
   active,
   onSelect,

--- a/frontend/slices/os-settings/index.ts
+++ b/frontend/slices/os-settings/index.ts
@@ -8,6 +8,7 @@ export const osSettingsApp: AppDescriptor = {
   title: "Settings",
   icon: Settings,
   gradient: "linear-gradient(160deg,#8a8f99,#5b6068)",
+  ownsMobileNavigation: true,
   load: () => import("./app"),
   defaultSize: { w: 840, h: 600 },
 };

--- a/frontend/slices/os-shell/brand-marks.test.tsx
+++ b/frontend/slices/os-shell/brand-marks.test.tsx
@@ -1,0 +1,30 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { APP_MARKS } from "./brand-marks";
+
+function markup(id: string) {
+  const Icon = APP_MARKS[id];
+  if (!Icon) throw new Error(`missing app mark ${id}`);
+  return renderToStaticMarkup(<Icon className="size-full" />);
+}
+
+describe("third-party official app marks", () => {
+  it.each([
+    ["camoufox-browser", "/brand/official/camoufox.webp"],
+    ["hermes", "/brand/official/hermes.webp"],
+    ["openclaw", "/brand/official/openclaw.webp"],
+  ])("keeps %s shell-invariant and official", (id, src) => {
+    const html = markup(id);
+    expect(html).toContain(`src="${src}"`);
+    expect(html).not.toContain("shell-artwork-macos");
+    expect(html).not.toContain("shell-artwork-windows");
+  });
+
+  it("keeps first-party app artwork platform-aware", () => {
+    const html = markup("files-manager");
+    expect(html).toContain("/app-icons/macos/files.webp");
+    expect(html).toContain("/app-icons/windows/files.webp");
+    expect(html).toContain("shell-artwork-macos");
+    expect(html).toContain("shell-artwork-windows");
+  });
+});

--- a/frontend/slices/os-shell/brand-marks.tsx
+++ b/frontend/slices/os-shell/brand-marks.tsx
@@ -7,6 +7,17 @@
 // those families: iOS = macOS artwork, Android = Windows artwork.
 import type { AppIconComponent } from "@/features/appshell";
 
+/** An official third-party brand mark is shell-invariant by definition. */
+function officialMark(src: string): AppIconComponent {
+  const Mark: AppIconComponent = ({ className: cls }) => (
+    // Small fixed local brand asset; image optimization adds no value here.
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt="" aria-hidden className={cls ?? "size-full object-contain"} draggable={false} decoding="async" />
+  );
+  Mark.displayName = `OfficialArtwork(${src})`;
+  return Mark;
+}
+
 /** One app identity with distinct native-looking artwork per desktop shell. */
 function platformMark(fallback: string, macos: string, windows: string): AppIconComponent {
   const Mark: AppIconComponent = ({ className: cls }) => {
@@ -32,7 +43,7 @@ export const APP_MARKS: Record<string, AppIconComponent> = {
     "/app-icons/macos/files.webp",
     "/app-icons/windows/files.webp",
   ),
-  "camoufox-browser": platformMark("/brand/official/camoufox.webp", "/app-icons/macos/camoufox.webp", "/app-icons/windows/camoufox.webp"),
+  "camoufox-browser": officialMark("/brand/official/camoufox.webp"),
   "code-editor": platformMark(
     "/app-icons/code.webp",
     "/app-icons/macos/code.webp",
@@ -78,8 +89,8 @@ export const APP_MARKS: Record<string, AppIconComponent> = {
     "/app-icons/macos/docs.webp",
     "/app-icons/windows/docs.webp",
   ),
-  hermes: platformMark("/brand/official/hermes.webp", "/app-icons/macos/hermes.webp", "/app-icons/windows/hermes.webp"),
-  openclaw: platformMark("/brand/official/openclaw.webp", "/app-icons/macos/openclaw.webp", "/app-icons/windows/openclaw.webp"),
+  hermes: officialMark("/brand/official/hermes.webp"),
+  openclaw: officialMark("/brand/official/openclaw.webp"),
 };
 
 export const HermesMark = APP_MARKS.hermes;

--- a/frontend/slices/shell-settings/components/section.tsx
+++ b/frontend/slices/shell-settings/components/section.tsx
@@ -28,8 +28,8 @@ export function SettingsSection({
 }) {
   return (
     <section className={cn("space-y-2", className)}>
-      <div className="flex items-center gap-2 px-1 text-muted-foreground">
-        <span className="[&_svg]:size-3.5">{icon}</span>
+      <div data-slot="settings-section-heading" className="flex items-center gap-2 px-1 text-muted-foreground">
+        <span data-slot="settings-section-icon" className="[&_svg]:size-3.5">{icon}</span>
         <span data-slot="settings-section-title" className="text-[11px] font-semibold uppercase tracking-wide">{title}</span>
       </div>
       {bare ? children : <div data-slot="settings-card" className="overflow-hidden rounded-xl border bg-card">{children}</div>}

--- a/scripts/e2e/shell.mjs
+++ b/scripts/e2e/shell.mjs
@@ -177,6 +177,16 @@ async function session(browser, { width, height, label, touch = width < 768, exp
     // A spinner that never resolves is the exact failure window-content.tsx used to
     // sit in forever when a chunk import rejected.
     check((await page.locator(".animate-spin").count()) === 0, `/${slug} rendered without a stuck spinner`);
+
+    // iOS System Settings deliberately owns its own navigation chrome. Guard the
+    // Apple-style hierarchy so the generic app header (icon/title/Done) cannot
+    // silently reappear and duplicate the in-app Settings navigation.
+    if (slug === "settings" && shell === "ios") {
+      check((await page.locator('[data-slot="ios-settings-root"]').count()) === 1, "/settings uses the native iOS Settings root");
+      check((await page.locator('[data-slot="ios-settings-root"] h1', { hasText: "Settings" }).count()) === 1, "/settings shows the iOS large title");
+      check((await page.locator('[data-slot="ios-settings-root"] input[type="search"]').count()) === 1, "/settings exposes functional Search");
+      check((await page.getByRole("button", { name: "Done", exact: true }).count()) === 0, "/settings does not duplicate the generic iOS Done header");
+    }
   }
 
   // ── the regression that shipped for months: a tool/list that renders every file


### PR DESCRIPTION
## Summary
- make iOS Settings own its native navigation hierarchy with a large Settings title, functional Search, grouped inset cards, icon tiles/chevrons, and Settings back navigation on detail pages
- keep Appearance/Theme control-heavy pages in the Display & Brightness style while using hero identity cards for other settings categories
- keep Android/macOS/Windows/Dashboard settings behavior unchanged
- restore Hermes, OpenClaw, and Camoufox to their official original brand icons on every shell

## Verification
- production-like build: pass
- shell E2E: desktop 1280×800, iOS portrait 390×844, phone landscape 844×390 → desktop: pass
- iOS Settings regression: native root, large title, functional Search, no duplicate generic Done header: pass
- official third-party icon regression: pass
- pre-push gate: 1547 tests pass, typecheck/lint pass, out-of-tree build pass, 0 WCAG AA contrast failures, high/critical audit clean
