### PR TITLE
fix(mobile): stabilize widgets back and viewport

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -688,3 +688,16 @@ body {
 [data-slot="shell-dialog-surface"][data-shell-id="windows"] {
   background: color-mix(in srgb, var(--window-bg) 95%, var(--accent) 5%);
 }
+
+/* Mobile widget persona + containment. The widget behavior/data stays shared;
+   only the surface follows the active phone shell. X is always clipped at the
+   Today/Widgets boundary so one long Quicklink can never create a second axis. */
+[data-shell="ios"] { --widget-bg: var(--glass-menu); }
+[data-shell="android"] { --widget-bg: color-mix(in srgb, var(--card) 92%, var(--accent) 8%); }
+[data-shell="android"] [data-slot="widget-card"] {
+  border-color: color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 24px;
+  backdrop-filter: none;
+}
+[data-shell="ios"] [data-slot="widget-card"] { border-radius: 22px; }
+[data-slot="mobile-widgets"], [data-slot="quicklinks-widget-grid"] { max-width: 100%; }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 ## 2026-08-23
 
+**Fixed**
+
+- `mobile` stabilize widgets back and viewport
+
 **Changed**
 
 - `ui` separate shell design systems

--- a/frontend/slices/appshell/components/desktop.tsx
+++ b/frontend/slices/appshell/components/desktop.tsx
@@ -73,12 +73,12 @@ function Surface() {
   // value here: the pre-hydration script in app/layout.tsx sets data-theme before
   // first paint.
   if (!mounted) {
-    return <div id="main-content" className="relative h-dvh w-screen overflow-hidden bg-background" />;
+    return <div id="main-content" className="relative w-screen overflow-hidden bg-background" style={{ height: "var(--mso-visual-vh, 100dvh)" }} />;
   }
 
   return (
     <ActiveShellProvider id={desc.id} surface={surface}>
-      <div id="main-content" data-shell={desc.id} className="relative h-dvh w-screen overflow-hidden">
+      <div id="main-content" data-shell={desc.id} className="relative w-screen overflow-hidden" style={{ height: "var(--mso-visual-vh, 100dvh)" }}>
         <Wallpaper shellDefault={desc.wallpaper} />
         <ContextMenuHost>
           <Suspense fallback={null}>

--- a/frontend/slices/appshell/components/shells/android/android-browser-back.test.ts
+++ b/frontend/slices/appshell/components/shells/android/android-browser-back.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("Android real-phone navigation contract", () => {
+  it("uses browser Back on real phones and only renders fake system nav in PhoneFrame", () => {
+    const src = readFileSync(new URL("./android-shell.tsx", import.meta.url), "utf8");
+    expect(src).toContain("useAndroidBrowserBack(!showSystemNav, browserLayer)");
+    expect(src).toContain("showSystemNav && <NavBar");
+    expect(src).toContain('"--android-nav": showSystemNav ? "48px" : "0px"');
+  });
+});

--- a/frontend/slices/appshell/components/shells/android/android-shell.tsx
+++ b/frontend/slices/appshell/components/shells/android/android-shell.tsx
@@ -29,10 +29,14 @@ import { ShellContextMenu, useShellContextMenu } from "../context-menu";
 import type { AppDescriptor } from "../../../lib/types";
 import { AndroidNotifications } from "./android-notifications";
 import { useMobileNavigationInfo } from "../../../lib/mobile-navigation";
+import { useResponsive } from "../../../responsive/use-responsive";
+import { useAndroidBrowserBack } from "./use-android-browser-back";
 import { AndroidFeatureHeader } from "./android-feature-header";
 
 function AndroidShell() {
   const apps = useApps();
+  const responsive = useResponsive();
+  const showSystemNav = responsive.vw >= 768; // only the desktop PhoneFrame preview draws fake Android system buttons
   const order = useWindowOrder();
   const focused = useFocused();
   const [drawer, setDrawer] = useState(false);
@@ -75,17 +79,34 @@ function AndroidShell() {
     },
     [apps, launch],
   );
-  const goHome = () => {
+  const goHome = useCallback(() => {
     if (topId) minimizeWindow(topId);
     setHome(true);
     setDrawer(false);
     setRecents(false);
-  };
+    setCc(false);
+    setNotif(false);
+  }, [topId, setHome]);
   const resume = (id: string) => {
     restoreWindow(id);
     setRecents(false);
     setHome(false);
   };
+  const browserLayer = drawer
+    ? { key: "drawer", onBack: () => setDrawer(false) }
+    : showApp && activeApp
+      ? {
+          key: mobileNav?.backLabel && mobileNav.backLabel !== "Home"
+            ? `detail:${activeApp.id}:${mobileNav.title}`
+            : `app:${activeApp.id}`,
+          onBack: mobileNav?.onBack ?? goHome,
+        }
+      : null;
+  // On a real Android phone the browser/OS already owns the system Back gesture.
+  // Mirror shell layers into same-URL history entries so that gesture closes the
+  // app drawer/detail/app before it ever navigates away from MSO. PhoneFrame keeps
+  // the simulated 3-button row for desktop preview and does not install this trap.
+  const browserBack = useAndroidBrowserBack(!showSystemNav, browserLayer);
   // Pull-DOWN on home: LEFT half → notifications, RIGHT half → Control Center
   // (mirrors the iOS split). The grid keeps scrolling — the pull only arms at top.
   const pullDown = usePullDown((sx) => (sx < window.innerWidth / 2 ? setNotif(true) : setCc(true)), gridRef);
@@ -116,12 +137,12 @@ function AndroidShell() {
     <ShellUIProvider value={shellUI}>
       <div
         className="absolute inset-0 z-[10] flex flex-col overflow-hidden text-foreground"
-        style={{ "--android-nav": "48px" } as CSSProperties}
+        style={{ "--android-nav": showSystemNav ? "48px" : "0px" } as CSSProperties}
       >
         {/* HOME (always mounted; app overlays it — inert while covered so its
             grid + NavBar drop out of tab/AT order under the z-20 app layer).
             Pull down → Control Center; clock+date live on the wallpaper. */}
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 pb-1" inert={showApp} aria-hidden={showApp} onPointerDown={pullDown} onContextMenu={onHomeContext} style={{ paddingTop: "var(--sai-top, 0px)" }}>
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 pb-1" inert={showApp} aria-hidden={showApp} onPointerDown={pullDown} onContextMenu={onHomeContext} style={{ paddingTop: "var(--sai-top, 0px)", paddingBottom: showSystemNav ? undefined : "var(--sai-bottom)" }}>
           {/* Same reason as the app labels: the clock sits on the wallpaper, so it
               needs its own light-on-dark treatment rather than the theme foreground. */}
           {/* `[&_div]:text-white/80` targets Clock mode="date", which hard-codes
@@ -141,7 +162,7 @@ function AndroidShell() {
             <span className="text-sm text-muted-foreground">Search</span>
           </button>
           {/* Home widgets — shared Today surface, height-capped so it never crowds the grid. */}
-          <div className="mt-4 max-h-[36vh] shrink-0 overflow-y-auto [scrollbar-width:none]">
+          <div className="mt-4 max-h-[36vh] min-w-0 max-w-full shrink-0 overflow-x-hidden overflow-y-auto [scrollbar-width:none]">
             <Slot region="today" />
           </div>
           {/* EVERY dockable app gets a home icon — the old slice(0, 12) cap hid most of
@@ -170,7 +191,7 @@ function AndroidShell() {
           </Button>
         </div>
 
-        <NavBar inactive={showApp} onBack={goHome} onHome={goHome} onRecents={() => setRecents(true)} />
+        {showSystemNav && <NavBar inactive={showApp} onBack={goHome} onHome={goHome} onRecents={() => setRecents(true)} />}
 
         {/* Fullscreen app. Open = M3 SPATIAL SLOW (k=200, ζ=0.8, ~511ms). The speed
             tier is chosen by the SIZE of the thing that moves, not by how far it
@@ -185,17 +206,17 @@ function AndroidShell() {
             <AndroidFeatureHeader
               title={mobileNav?.title ?? activeApp.title}
               backLabel={mobileNav?.backLabel ?? "Home"}
-              onBack={mobileNav?.onBack ?? goHome}
+              onBack={() => browserBack()}
               onAI={toggleInspector}
             />
             <main className="relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto [container-type:inline-size]">
               <WindowContent app={top.app} payload={top.payload} />
             </main>
-            <NavBar onBack={mobileNav?.onBack ?? goHome} onHome={goHome} onRecents={() => setRecents(true)} />
+            {showSystemNav && <NavBar onBack={mobileNav?.onBack ?? goHome} onHome={goHome} onRecents={() => setRecents(true)} />}
           </div>
         )}
 
-        {drawer && <AppDrawer apps={dockable} onLaunch={launch} onClose={() => setDrawer(false)} />}
+        {drawer && <AppDrawer apps={dockable} onLaunch={launch} onClose={() => browserBack()} />}
         {recents && <Recents order={order} apps={apps} onResume={resume} onHome={goHome} />}
         {/* live-activity chip (parity with iOS Dynamic Island) — renders only
             while an app reports an activity (render/copy…); reads the same store. */}

--- a/frontend/slices/appshell/components/shells/android/use-android-browser-back.ts
+++ b/frontend/slices/appshell/components/shells/android/use-android-browser-back.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+export type AndroidBackLayer = { key: string; onBack: () => void } | null;
+const STATE_KEY = "__msoAndroidLayer";
+
+/**
+ * Bridges MSO's internal Android navigation to the real Android/browser Back.
+ * Each visible internal layer gets a same-URL history entry. Back pops that entry
+ * and runs the layer's existing onBack action instead of leaving the site.
+ */
+export function useAndroidBrowserBack(enabled: boolean, layer: AndroidBackLayer) {
+  const layerRef = useRef(layer);
+  const suppressNextPush = useRef(false);
+  const layerKey = layer?.key ?? null;
+
+  useEffect(() => {
+    layerRef.current = layer;
+  }, [layer]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const onPop = () => {
+      const current = layerRef.current;
+      if (!current) return;
+      suppressNextPush.current = true;
+      current.onBack();
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (suppressNextPush.current) {
+      suppressNextPush.current = false;
+      return;
+    }
+    if (!layerKey) return;
+
+    const state = (window.history.state ?? {}) as Record<string, unknown>;
+    const current = state[STATE_KEY];
+    if (current === layerKey) return;
+
+    // Launching from All Apps replaces that transient drawer entry with the app
+    // entry, so Back goes to Home rather than reopening a drawer the user left.
+    if (current === "drawer" && layerKey.startsWith("app:")) {
+      window.history.replaceState({ ...state, [STATE_KEY]: layerKey }, "", window.location.href);
+      return;
+    }
+    window.history.pushState({ ...state, [STATE_KEY]: layerKey }, "", window.location.href);
+  }, [enabled, layerKey]);
+
+  return useCallback(() => {
+    const current = layerRef.current;
+    if (!current) return;
+    if (!enabled) {
+      current.onBack();
+      return;
+    }
+    const marker = (window.history.state as Record<string, unknown> | null)?.[STATE_KEY];
+    if (marker === current.key) window.history.back();
+    else current.onBack();
+  }, [enabled]);
+}

--- a/frontend/slices/appshell/design/android/design.md
+++ b/frontend/slices/appshell/design/android/design.md
@@ -11,3 +11,12 @@ Design family: Material 3 / Material You.
 - Modal mobile flows use Material bottom sheets/drawers; destructive confirmations remain explicit.
 - Use M3 motion tokens/springs already defined by the Android shell and honor Reduce Motion.
 - Bottom system navigation remains shell-owned; feature navigation must not duplicate Android Back.
+
+## Real-device navigation
+- On an actual narrow Android handset, do not draw a second simulated 3-button system navigation bar; the device/browser already owns that system chrome.
+- MSO internal layers publish same-URL history entries so Android/browser Back closes All Apps, a detail view, or the current MSO app before leaving the shell.
+- The simulated Back/Home/Recents row is reserved for the desktop PhoneFrame preview where no real Android system navigation exists.
+
+## Widgets
+- Mobile widgets use the active mobile surface. The Shell widget offers iOS/Android on mobile and desktop personas only on desktop.
+- Widget stacks scroll vertically only; cards, Quicklinks, and Quick open grids must never widen the Today/Widgets viewport.

--- a/frontend/slices/appshell/features/widgets/components/mobile-widget-layout.test.ts
+++ b/frontend/slices/appshell/features/widgets/components/mobile-widget-layout.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("mobile widget layout policy", () => {
+  it("Shell widget selects the active surface instead of hard-coding desktop", () => {
+    const src = readFileSync(new URL("./widgets-defs-vps.tsx", import.meta.url), "utf8");
+    expect(src).toContain("shellsForSurface(surface)");
+    expect(src).toContain("setShell(surface, s.id)");
+    expect(src).not.toContain('shellsForSurface("desktop")');
+  });
+
+  it("Quicklinks and the mobile widget stack clip horizontal overflow", () => {
+    const defs = readFileSync(new URL("./widgets-defs.tsx", import.meta.url), "utf8");
+    const mobile = readFileSync(new URL("./mobile-widgets.tsx", import.meta.url), "utf8");
+    expect(defs).toContain('data-slot="quicklinks-widget-grid"');
+    expect(defs).toContain("overflow-x-clip");
+    expect(mobile).toContain("overflow-x-clip");
+    expect(mobile).toContain('data-slot="quick-open-grid"');
+    expect(mobile).toContain("grid-cols-4");
+  });
+});

--- a/frontend/slices/appshell/features/widgets/components/mobile-widgets.tsx
+++ b/frontend/slices/appshell/features/widgets/components/mobile-widgets.tsx
@@ -3,7 +3,7 @@
 import { createElement } from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { useApps, useShellUI, AppIcon, type AppDescriptor } from "@/features/appshell";
+import { useApps, useShellUI, useActiveShell, AppIcon, type AppDescriptor } from "@/features/appshell";
 import { Card } from "./widget-cards";
 import { useWidgetState, setPickerOpen } from "../widget-registry";
 import { WIDGET_RENDER } from "./widgets-defs";
@@ -16,15 +16,16 @@ import { WidgetPicker } from "./widget-picker";
 // app row from the shell-UI context.
 export function MobileWidgets() {
   const apps = useApps();
+  const shell = useActiveShell();
   const { quickAppIds: quickIds, openApp: onOpen } = useShellUI();
   const { enabled } = useWidgetState();
 
   const quick = quickIds.map((id) => apps.find((a) => a.id === id)).filter(Boolean) as AppDescriptor[];
 
   return (
-    <div className="flex h-full flex-col gap-3 overflow-y-auto px-4 py-3 [scrollbar-width:none]">
+    <div data-slot="mobile-widgets" className="flex h-full w-full min-w-0 max-w-full flex-col gap-3 overflow-x-clip overflow-y-auto px-4 py-3 [scrollbar-width:none]">
       <div className="flex items-center justify-between px-1">
-        <h2 className="text-[28px] font-extrabold tracking-[-0.02em] text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.5)]">Today</h2>
+        <h2 className="text-[28px] font-extrabold tracking-[-0.02em] text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.5)]">{shell.id === "android" ? "Widgets" : "Today"}</h2>
         {/* Edit the glanceable VPS telemetry set right from the phone — opens the
             shared widget picker (add/remove Clock/Notes/Quicklinks/CPU/Mem/…). */}
         <Button
@@ -46,9 +47,9 @@ export function MobileWidgets() {
       {quick.length > 0 && (
         <Card>
           <span className="mb-2 block text-[12px] font-semibold text-muted-foreground">Quick open</span>
-          <div className="flex gap-4">
+          <div data-slot="quick-open-grid" className="grid min-w-0 max-w-full grid-cols-4 gap-x-3 gap-y-3 overflow-x-clip">
             {quick.map((app) => (
-              <Button key={app.id} type="button" variant="ghost" onClick={() => onOpen(app)} className="h-auto p-0 hover:bg-transparent flex flex-col items-center gap-1.5">
+              <Button key={app.id} type="button" variant="ghost" onClick={() => onOpen(app)} className="h-auto min-w-0 max-w-full p-0 hover:bg-transparent flex flex-col items-center gap-1.5 overflow-hidden">
                 <span className="size-12">
                   <AppIcon app={app} />
                 </span>

--- a/frontend/slices/appshell/features/widgets/components/widget-cards.tsx
+++ b/frontend/slices/appshell/features/widgets/components/widget-cards.tsx
@@ -22,10 +22,11 @@ export function Card({ children, className }: { children: React.ReactNode; class
       // (Border needs no var: the global `* { border-color: --border }` in
       // globals.css already unifies every border to the window edge color.)
       className={cn(
-        "rounded-[var(--widget-radius,1rem)] border border-white/15 p-3.5 text-foreground backdrop-blur-xl",
+        "min-w-0 max-w-full rounded-[var(--widget-radius,1rem)] border border-white/15 p-3.5 text-foreground backdrop-blur-xl",
         className,
       )}
-      style={{ background: "var(--glass-menu)" }}
+      data-slot="widget-card"
+      style={{ background: "var(--widget-bg, var(--glass-menu))" }}
     >
       {children}
     </div>

--- a/frontend/slices/appshell/features/widgets/components/widgets-defs-vps.tsx
+++ b/frontend/slices/appshell/features/widgets/components/widgets-defs-vps.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Code2, FileText, Globe, Moon, Palette, Sun, Timer as TimerIcon } from "lucide-react";
-import { setShell, shellsForSurface, useShellAppearance, useShellPrefs } from "@/features/appshell";
+import { setShell, shellsForSurface, useActiveShell, useShellAppearance, useShellPrefs } from "@/features/appshell";
 import { cn } from "@/lib/utils";
 import { Card } from "./widget-cards";
 import { mdToHtml } from "./md";
@@ -118,11 +118,13 @@ function HtmlWidget() {
   );
 }
 
-// Switches the active DESKTOP shell (macOS / Windows / Dashboard). VPS-native —
-// reads the shell registry directly (brand-free).
+// Switches the active shell for the CURRENT surface. On a phone this intentionally
+// offers iOS/Android; desktop widgets offer macOS/Windows/Dashboard.
 function ShellWidget() {
   const prefs = useShellPrefs();
-  const shells = shellsForSurface("desktop");
+  const { surface } = useActiveShell();
+  const shells = shellsForSurface(surface);
+  const active = prefs[surface];
   return (
     <Card className="pointer-events-auto">
       <div className="mb-2 flex items-center gap-2">
@@ -134,10 +136,10 @@ function ShellWidget() {
           <button
             key={s.id}
             type="button"
-            onClick={() => setShell("desktop", s.id)}
+            onClick={() => setShell(surface, s.id)}
             className={cn(
               "flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs",
-              prefs.desktop === s.id ? "bg-primary text-primary-foreground" : "hover:bg-white/10",
+              active === s.id ? "bg-primary text-primary-foreground" : "hover:bg-white/10",
             )}
           >
             <s.icon className="size-4 shrink-0" />

--- a/frontend/slices/appshell/features/widgets/components/widgets-defs.tsx
+++ b/frontend/slices/appshell/features/widgets/components/widgets-defs.tsx
@@ -108,18 +108,18 @@ function QuicklinksWidget() {
         <Link2 className="size-4 text-muted-foreground" />
         <span className="text-[12.5px] font-semibold">Quicklinks</span>
       </div>
-      <div className="grid grid-cols-4 gap-2">
+      <div data-slot="quicklinks-widget-grid" className="grid min-w-0 max-w-full grid-cols-4 gap-2 overflow-x-clip">
         {items.slice(0, 8).map((link) => (
           <button
             key={link.id}
             type="button"
             onClick={() => open(link)}
-            className="flex flex-col items-center gap-1 rounded-md p-1 hover:bg-white/10"
+            className="flex min-w-0 max-w-full flex-col items-center gap-1 overflow-hidden rounded-md p-1 hover:bg-white/10"
           >
             <span className="size-8">
               <QuicklinkIcon link={link} />
             </span>
-            <span className="max-w-[52px] truncate text-[9px] font-medium">{link.title}</span>
+            <span className="w-full max-w-[52px] truncate text-center text-[9px] font-medium">{link.title}</span>
           </button>
         ))}
       </div>

--- a/frontend/slices/appshell/responsive/mobile-height-policy.test.ts
+++ b/frontend/slices/appshell/responsive/mobile-height-policy.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("mobile full-height policy", () => {
+  it("sizes the shell from the synchronized visual viewport token", () => {
+    const surface = readFileSync(new URL("../components/desktop.tsx", import.meta.url), "utf8");
+    const provider = readFileSync(new URL("./responsive-provider.tsx", import.meta.url), "utf8");
+    expect(surface).toContain("--mso-visual-vh");
+    expect(surface).not.toContain('className="relative h-dvh w-screen');
+    expect(provider).toContain('window.visualViewport?.addEventListener("resize", schedule)');
+    expect(provider).toContain('(orientation: portrait)');
+  });
+});

--- a/frontend/slices/appshell/responsive/responsive-provider.test.ts
+++ b/frontend/slices/appshell/responsive/responsive-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sameGeometry, shouldUseMobileSurface } from "./responsive-provider";
+import { effectiveVisualViewportHeight, sameGeometry, shouldUseMobileSurface } from "./responsive-provider";
 import type { Responsive } from "./use-responsive";
 
 const base: Responsive = {
@@ -61,7 +61,23 @@ describe("shouldUseMobileSurface", () => {
     expect(shouldUseMobileSurface("auto", 820, 1180, false)).toBe(false);
   });
 
+  it("does not flip a portrait phone to desktop when the keyboard shrinks innerHeight", () => {
+    expect(shouldUseMobileSurface("auto", 390, 320, true, true)).toBe(true);
+    expect(shouldUseMobileSurface("auto", 844, 390, true, false)).toBe(false);
+  });
+
   it("desktop override always stays desktop", () => {
     expect(shouldUseMobileSurface("desktop", 390, 844, true)).toBe(false);
+  });
+});
+
+
+describe("effectiveVisualViewportHeight", () => {
+  it("tracks browser chrome and keyboard at normal scale", () => {
+    expect(effectiveVisualViewportHeight(844, 706.4, 1)).toBe(706);
+  });
+
+  it("does not resize the shell during pinch zoom", () => {
+    expect(effectiveVisualViewportHeight(844, 422, 2)).toBe(844);
   });
 });

--- a/frontend/slices/appshell/responsive/responsive-provider.tsx
+++ b/frontend/slices/appshell/responsive/responsive-provider.tsx
@@ -16,14 +16,23 @@ const TABLET_W = 1024; // touch-portrait tablets below this read as mobile
  * deliberately the desktop surface so a rotated phone gets the denser desktop
  * workspace instead of a stretched phone shell. A forced phone preview follows
  * the same rule — the override selects the portrait persona, not orientation. */
-export function shouldUseMobileSurface(device: DeviceMode, vw: number, vh: number, coarse: boolean): boolean {
-  const portrait = vh >= vw;
+export function shouldUseMobileSurface(device: DeviceMode, vw: number, vh: number, coarse: boolean, portraitOverride?: boolean): boolean {
+  const portrait = portraitOverride ?? vh >= vw;
   if (device === "desktop") return false;
   // Keep the explicit Phone preview usable on a wide desktop: it renders inside
   // PhoneFrame. On an actual phone-width landscape viewport, switch to desktop.
   if (device === "phone") return portrait || vw >= TABLET_W;
   if (!portrait) return false;
   return vw < MOBILE_W || (coarse && vw < TABLET_W);
+}
+
+
+/** The visual viewport is the actually visible browser area after dynamic URL bars
+ * and the soft keyboard are accounted for. Ignore it while pinch-zoomed: resizing
+ * the entire shell to a zoomed viewport makes content jump under accessibility zoom. */
+export function effectiveVisualViewportHeight(innerHeight: number, visualHeight?: number, scale = 1): number {
+  if (visualHeight && visualHeight > 0 && Math.abs(scale - 1) < 0.01) return Math.round(visualHeight);
+  return Math.max(1, Math.round(innerHeight));
 }
 
 function bucket(vw: number): Pane {
@@ -102,9 +111,14 @@ export function ResponsiveProvider({
     const measure = () => {
       const vw = window.innerWidth;
       const vh = window.innerHeight;
+      const vv = window.visualViewport;
+      const visibleHeight = effectiveVisualViewportHeight(vh, vv?.height, vv?.scale ?? 1);
+      document.documentElement.style.setProperty("--mso-visual-vh", `${visibleHeight}px`);
       const coarse = window.matchMedia?.("(pointer: coarse)").matches ?? false;
-      const portrait = vh >= vw;
-      const isMobile = shouldUseMobileSurface(device, vw, vh, coarse);
+      // CSS orientation is based on the layout viewport and does not flip when a
+      // portrait phone opens its keyboard (innerHeight can temporarily become < width).
+      const portrait = window.matchMedia?.("(orientation: portrait)").matches ?? vh >= vw;
+      const isMobile = shouldUseMobileSurface(device, vw, vh, coarse, portrait);
       const next: Responsive = {
         formFactor: isMobile ? "mobile" : "desktop",
         isMobile,
@@ -138,10 +152,14 @@ export function ResponsiveProvider({
     measure();
     window.addEventListener("resize", schedule);
     window.addEventListener("orientationchange", schedule);
+    window.visualViewport?.addEventListener("resize", schedule);
+    window.visualViewport?.addEventListener("scroll", schedule);
     return () => {
       if (raf) cancelAnimationFrame(raf);
       window.removeEventListener("resize", schedule);
       window.removeEventListener("orientationchange", schedule);
+      window.visualViewport?.removeEventListener("resize", schedule);
+      window.visualViewport?.removeEventListener("scroll", schedule);
     };
   }, [device]);
 

--- a/scripts/e2e/shell.mjs
+++ b/scripts/e2e/shell.mjs
@@ -152,6 +152,14 @@ async function session(browser, { width, height, label, touch = width < 768, exp
     document.documentElement.scrollWidth - document.documentElement.clientWidth,
   );
   check(overflow <= 1, `no horizontal overflow (${overflow}px)`);
+  if (expectedSurface === "mobile") {
+    const viewportDelta = await page.evaluate(() => {
+      const root = document.querySelector("#main-content");
+      const visible = window.visualViewport?.height ?? window.innerHeight;
+      return Math.abs((root?.getBoundingClientRect().height ?? 0) - visible);
+    });
+    check(viewportDelta <= 1, `root height follows the visual viewport (${viewportDelta.toFixed(1)}px delta)`);
+  }
 
   // ── open every app by DEEP LINK rather than by clicking the dock.
   //


### PR DESCRIPTION
## Summary
- make mobile Shell widget follow active surface (iOS/Android on mobile; desktop personas on desktop)
- contain every mobile widget to vertical-only scrolling and wrap Quick open; prevent Quicklinks/long labels from widening Android widget cards
- bridge Android internal menu/app/detail layers to browser/system Back; hide simulated 3-button Android nav on real phones while preserving it in desktop PhoneFrame preview
- size the shell from the normal-scale Visual Viewport and preserve orientation while the soft keyboard/browser chrome changes height
- add regression tests and official E2E root-height assertion

## Verification
- all 16 widgets: iOS + Android at 320/360/390px, zero widget X overflow
- Android browser/system Back: All Apps -> Home; Settings detail -> root; app -> Home
- iOS + Android height: 844 -> 700 -> 812px, root matches visible viewport exactly
- production build + official shell E2E pass
- full pre-push: 1561 tests pass, typecheck/lint, cycles, contrast, security audit, out-of-tree build pass
