### PR TITLE
fix(android): clear notch in app drawer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `android` clear notch in app drawer
 - `mobile` stabilize widgets back and viewport
 
 **Changed**

--- a/frontend/slices/appshell/components/shells/android/android-app-drawer.test.ts
+++ b/frontend/slices/appshell/components/shells/android/android-app-drawer.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("Android All apps drawer contract", () => {
+  it("has an explicit Home back control and safe-area-aware top region", () => {
+    const src = readFileSync(new URL("./android-parts.tsx", import.meta.url), "utf8");
+    expect(src).toContain('aria-label="Back to Home"');
+    expect(src).toContain('data-slot="android-app-drawer-top"');
+    expect(src).toContain('calc(var(--sai-top, 0px) + 8px)');
+    expect(src).toContain('h-[48px] min-h-[48px]');
+    expect(src).toContain('<h1 className="mx-auto text-[18px] font-medium">All apps</h1>');
+  });
+});

--- a/frontend/slices/appshell/components/shells/android/android-parts.tsx
+++ b/frontend/slices/appshell/components/shells/android/android-parts.tsx
@@ -169,21 +169,44 @@ export function AppDrawer({ apps, onLaunch, onClose }: { apps: AppDescriptor[]; 
     // rising from where the finger was. (That target is drawn as a grabber but is a
     // plain tap — there is no swipe-up gesture in this shell, only usePullDown for
     // the shade and useSwipeUpClose for Recents cards.)
-    <div className="absolute inset-0 z-[30] flex flex-col bg-background/95 backdrop-blur-xl [animation:mobileAppOpen_var(--m3-dur-spatial-slow)_var(--m3-spatial)]">
-      {/* Visually a thin pull handle, but a ≥36px hit area (same treatment as
-          the iOS home indicator) so it's actually closable by thumb. */}
-      <Button
-        type="button"
-        variant="ghost"
-        onClick={onClose}
-        aria-label="Close app drawer"
-        className="mx-auto flex h-9 w-24 items-center justify-center p-0 hover:bg-transparent"
+    <div data-slot="android-app-drawer" className="absolute inset-0 z-[30] flex flex-col bg-background/95 backdrop-blur-xl [animation:mobileAppOpen_var(--m3-dur-spatial-slow)_var(--m3-spatial)]">
+      {/* Keep every top control below the physical notch/status area. The extra
+          8px gives the grab handle breathing room even when env(safe-area-inset-top)
+          resolves to zero in a normal browser/PWA window. */}
+      <div
+        data-slot="android-app-drawer-top"
+        className="shrink-0"
+        style={{ paddingTop: "calc(var(--sai-top, 0px) + 8px)" }}
       >
-        <span className="h-1 w-10 rounded-full bg-foreground/30" />
-      </Button>
-      <div className="mx-4 mt-1 flex h-11 items-center gap-3 rounded-full border border-border bg-card px-4">
-        <Search className="size-4 text-muted-foreground" />
-        <input autoFocus value={q} onChange={(e) => setQ(e.target.value)} aria-label="Search apps" placeholder="Search apps" className="w-full bg-transparent text-sm outline-none" />
+        {/* The handle remains a close target, but it is no longer the ONLY visible
+            way out. On real phones onClose is routed through the same history-aware
+            Back bridge as the hardware/browser gesture. */}
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onClose}
+          aria-label="Close app drawer"
+          className="mx-auto flex h-[28px] w-24 items-center justify-center p-0 hover:bg-transparent"
+        >
+          <span className="h-1 w-10 rounded-full bg-foreground/30" />
+        </Button>
+        <div className="relative flex h-[48px] items-center px-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            aria-label="Back to Home"
+            className={`absolute left-1 top-1/2 h-[48px] min-h-[48px] -translate-y-1/2 gap-0 rounded-full px-1.5 text-[15px] font-medium hover:bg-secondary ${M3_PRESS}`}
+          >
+            <ChevronLeft className="size-6 shrink-0" aria-hidden />
+            <span>Home</span>
+          </Button>
+          <h1 className="mx-auto text-[18px] font-medium">All apps</h1>
+        </div>
+        <div className="mx-4 mb-3 mt-1 flex h-[48px] items-center gap-3 rounded-full border border-border bg-card px-4">
+          <Search className="size-4 text-muted-foreground" />
+          <input autoFocus value={q} onChange={(e) => setQ(e.target.value)} aria-label="Search apps" placeholder="Search apps" className="min-w-0 w-full bg-transparent text-sm outline-none" />
+        </div>
       </div>
       <div
         className="grid min-h-0 flex-1 grid-cols-4 content-start gap-x-3 gap-y-5 overflow-auto p-5"

--- a/frontend/slices/appshell/design/android/design.md
+++ b/frontend/slices/appshell/design/android/design.md
@@ -15,6 +15,7 @@ Design family: Material 3 / Material You.
 ## Real-device navigation
 - On an actual narrow Android handset, do not draw a second simulated 3-button system navigation bar; the device/browser already owns that system chrome.
 - MSO internal layers publish same-URL history entries so Android/browser Back closes All Apps, a detail view, or the current MSO app before leaving the shell.
+- All Apps also exposes a visible **‹ Home** control using that same history-aware close action; the top grab handle and search/header region must begin below `safe-area-inset-top` plus breathing room so notches/status bars never overlap it.
 - The simulated Back/Home/Recents row is reserved for the desktop PhoneFrame preview where no real Android system navigation exists.
 
 ## Widgets


### PR DESCRIPTION
Fix Android All apps mobile navigation and top safe-area layout.

- add explicit visible ‹ Home control in All apps
- route it through the existing history-aware Back action
- move grab handle/header/search below safe-area-inset-top + 8px breathing room
- keep Back target fixed at 48px independent of text scale
- keep Search below navigation row and prevent horizontal overflow
- update Android design contract + regression test

Verification:
- production build + official shell E2E pass
- 390×844 and 430×932 with simulated 59px notch safe-area pass
- explicit Back returns Home
- 1,562 tests pass; typecheck/lint/cycles/contrast/security/out-of-tree build pass