### PR TITLE
fix(security): harden GitHub quality controls

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -22,6 +21,9 @@ jobs:
     name: Analyze JavaScript/TypeScript
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ a certification or a substitute for an independent third-party audit.
 ## Reporting a vulnerability
 
 Do not open a public issue containing exploit details or secrets. GitHub private
-vulnerability reporting is enabled for this repository; use **Security → Report a vulnerability**.
+vulnerability reporting is enabled for this repository; use [**Report a vulnerability**](https://github.com/rahmanef63/mso/security/advisories/new).
 Include the affected commit, reproduction steps, impact and sanitized logs.
 
 Never post passwords, session secrets, API keys, bearer tokens, private file contents,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `security` harden GitHub quality controls
 - `security` canonicalize writable path containment
 
 ## 2026-08-29

--- a/lib/install-contract.test.ts
+++ b/lib/install-contract.test.ts
@@ -29,4 +29,14 @@ describe("one-line installer contract", () => {
     expect(src).toContain('export PATH="$BIN_DIR:$PATH"');
     expect(src).toContain('command -v mso');
   });
+
+  it("verifies a commit-pinned Bun bootstrap before execution", () => {
+    const src = fs.readFileSync(INSTALL, "utf8");
+    expect(src).toMatch(/BUN_BOOTSTRAP_COMMIT="[0-9a-f]{40}"/);
+    expect(src).toMatch(/BUN_BOOTSTRAP_SHA256="[0-9a-f]{64}"/);
+    expect(src).toContain('raw.githubusercontent.com/oven-sh/bun/$BUN_BOOTSTRAP_COMMIT/src/cli/install.sh');
+    expect(src).toContain('sha256sum "$bootstrap"');
+    expect(src).toContain('[ "$actual" = "$BUN_BOOTSTRAP_SHA256" ]');
+    expect(src).not.toContain('https://bun.sh/install | bash');
+  });
 });

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,6 +37,10 @@ ONBOARD_MODE=auto
 FRESH_INSTALL=0
 # bun is the package manager; the RUNTIME stays node (see ensure_bun below).
 export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+# Reproducible bootstrap: this is Bun v1.3.14's installer source, pinned by
+# immutable Git commit and verified before execution. Update both values together.
+BUN_BOOTSTRAP_COMMIT="0d9b296af33f2b851fcbf4df3e9ec89751734ba4"
+BUN_BOOTSTRAP_SHA256="bab8acfb046aac8c72407bdcce903957665d655d7acaa3e11c7c4616beae68dd"
 
 # ---- pretty output (tty + NO_COLOR aware) ----
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
@@ -163,8 +167,19 @@ ensure_node() {
 # node's ABI and the whole /api/v1 surface imports it.
 ensure_bun() {
   command -v bun >/dev/null 2>&1 && { info "bun $(bun -v) ok"; return; }
-  info "installing bun…"
-  curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || die "bun install failed."
+  command -v sha256sum >/dev/null 2>&1 || die "sha256sum is required to verify the Bun bootstrap."
+  info "installing Bun from a pinned, verified bootstrap…"
+  local bootstrap actual url
+  bootstrap="$(mktemp)"
+  url="https://raw.githubusercontent.com/oven-sh/bun/$BUN_BOOTSTRAP_COMMIT/src/cli/install.sh"
+  curl -fsSL "$url" -o "$bootstrap" || { rm -f "$bootstrap"; die "Bun bootstrap download failed."; }
+  actual="$(sha256sum "$bootstrap" | awk '{print $1}')"
+  [ "$actual" = "$BUN_BOOTSTRAP_SHA256" ] || {
+    rm -f "$bootstrap"
+    die "Bun bootstrap integrity check failed."
+  }
+  bash "$bootstrap" >/dev/null 2>&1 || { rm -f "$bootstrap"; die "bun install failed."; }
+  rm -f "$bootstrap"
   export PATH="$BUN_INSTALL/bin:$PATH"
   command -v bun >/dev/null 2>&1 || die "bun installed but not on PATH — add $BUN_INSTALL/bin."
 }


### PR DESCRIPTION
## Summary
- scope CodeQL write permission to the analysis job
- link private vulnerability reporting directly from SECURITY.md
- replace unpinned `curl | bash` Bun bootstrap with a commit-pinned, SHA-256-verified installer
- add regression coverage for the pinned bootstrap contract

## Verification
- full local pre-push gate passed
- 214 test files passed, 1 skipped; 1749 tests passed, 1 expected fail, 4 skipped
- typecheck/lint/repository checks/dependency audit passed
- isolated production build passed

This PR addresses actionable OpenSSF Scorecard findings without hiding governance gaps that require process changes.