### PR TITLE
fix(install): make WSL CLI setup reliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,18 @@ The flow lets you choose:
   from Alfa's credentials);
 - reviewed **installable skills** such as Ponytail, Caveman and the MSO-safe RTK wrapper.
 
-The installer also generates the owner login credentials, builds production, installs and
-starts `mso.service`, and installs the CLI in both `~/.local/bin/mso` and—when the normal
-service install has sudo available—`/usr/local/bin/mso`. That system launcher is important:
-a child `curl | bash` process cannot modify the PATH of the shell that launched it, so
-`mso -h` must work immediately **after the installer returns**, without asking you to
-restart the shell. The installer also adds an idempotent `~/.local/bin` fallback to the
-normal shell profile for future sessions.
+The installer generates the owner login credentials, builds production, and installs the CLI
+**before** it touches systemd. It always creates `~/.local/bin/mso`; when the invoking shell
+already has `/usr/local/bin` on `PATH`, it also installs a guarded `/usr/local/bin/mso`
+launcher (using sudo when needed). That order matters on WSL: a distro may ship a `systemctl`
+binary even when systemd is not PID 1, and a service setup problem must never prevent the CLI
+from being installed.
+
+A child `curl | bash` process cannot modify its parent shell's `PATH`. The installer therefore
+checks the **original invoking PATH** after creating the launchers and explicitly reports whether
+`mso -h` will work immediately. If neither launcher is already reachable from that PATH, the
+install still succeeds, persists `~/.local/bin` in the normal shell profile, and prints the exact
+`export PATH=...` command for the current shell instead of falsely claiming success.
 
 If the environment has no controlling TTY (CI/cloud-init), the installer never blocks. It
 prints the resume command instead:
@@ -143,7 +148,8 @@ skills:
 curl -fsSL https://raw.githubusercontent.com/rahmanef63/mso/main/scripts/install.sh | bash -s -- -y
 ```
 
-After installation these should work immediately:
+After installation, the installer prints whether the current shell can already resolve `mso`.
+On the normal Ubuntu/WSL PATH (which includes `/usr/local/bin`) these work immediately:
 
 ```bash
 mso -h
@@ -152,6 +158,14 @@ mso onboard                 # run/re-run guided setup
 mso skills available        # reviewed installable skill list
 mso skills install ponytail caveman rtk -y
 ```
+
+If it explicitly says the current shell cannot see the user launcher yet, run the one-line
+`export PATH="$HOME/.local/bin:$PATH"` it prints; new shells use the persisted profile entry.
+
+**WSL2:** the CLI is supported even when systemd is not active. In that case the installer now
+finishes the CLI instead of failing in `systemctl`, but it skips `mso.service`. For the full
+background service, enable systemd in `/etc/wsl.conf`, exit all WSL sessions from Windows, reopen
+the distro, then re-run the installer with `--onboard`.
 
 `Caveman`/`Ponytail` appear in two intentionally different places. **Response presets**
 (`mso config style caveman|ponytail`) are lightweight Alfa output policies. The market
@@ -332,10 +346,10 @@ Tested:
 - Ubuntu 22.04
 - Ubuntu 24.04
 
-Expected to work:
+Supported deployment shapes:
 
-- Debian 12
-- Other systemd-based Linux distributions with Node.js 20.9+ and build tools
+- WSL2 Ubuntu: CLI/install path works without systemd; the background service requires systemd enabled in WSL
+- Debian 12 and other systemd-based Linux distributions with Node.js 20.9+ and build tools
 
 Not currently supported:
 

--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -22,6 +22,14 @@ describe("/api/health", () => {
     expect((body.version as string).length).toBeGreaterThan(0);
   });
 
+  it("returns the runtime instance id supplied by the service manager", async () => {
+    vi.stubEnv("MSO_RUNTIME_INSTANCE_ID", "restart-proof-123");
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.runtimeInstanceId).toBe("restart-proof-123");
+  });
+
   it("sets Cache-Control: no-store", async () => {
     const { GET } = await import("./route");
     const res = await GET();

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -13,6 +13,7 @@ export async function GET() {
       {
         status: "ok",
         buildId: process.env.NEXT_PUBLIC_BUILD_ID || "dev",
+        runtimeInstanceId: process.env.MSO_RUNTIME_INSTANCE_ID || null,
         version: pkg.version ?? "0.0.0",
         demo: true,
       },
@@ -24,6 +25,7 @@ export async function GET() {
     {
       status: "ok",
       buildId: process.env.NEXT_PUBLIC_BUILD_ID || "dev",
+      runtimeInstanceId: process.env.MSO_RUNTIME_INSTANCE_ID || null,
       uptime: Math.round(process.uptime()),
       version: pkg.version ?? "0.0.0",
     },

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "@vitest/coverage-v8": "^4.1.11",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.3.2",
+        "fast-check": "^4.9.0",
         "postcss": "^8.5.26",
         "tailwindcss": "^4.3.0",
         "typescript": "^5.9.3",
@@ -682,6 +683,8 @@
 
     "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
@@ -1007,6 +1010,8 @@
     "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `install` make WSL CLI setup reliable
 - `security` harden GitHub quality controls
 - `security` canonicalize writable path containment
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `install` bind readiness to runtime instance
 - `install` preserve caller path semantics
 - `install` prove stable-id service takeover
 - `install` keep security hint literal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `install` keep security hint literal
 - `install` make WSL CLI setup reliable
 - `security` harden GitHub quality controls
 - `security` canonicalize writable path containment

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `install` prove stable-id service takeover
 - `install` keep security hint literal
 - `install` make WSL CLI setup reliable
 - `security` harden GitHub quality controls

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ this is the *what*, and it is what Settings → About shows as “What's new”.
 
 **Fixed**
 
+- `install` preserve caller path semantics
 - `install` prove stable-id service takeover
 - `install` keep security hint literal
 - `install` make WSL CLI setup reliable

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,7 +7,8 @@
 
 ## 0. Requirements
 
-- Linux with systemd;
+- Linux; systemd is required for the installed background service, but not for the CLI;
+- WSL2 is supported for the CLI. Full service mode requires systemd enabled as PID 1;
 - Node.js 20.9+ (Node 22 recommended/current production runtime);
 - Bun for dependency installation/scripts;
 - a non-root user that owns MSO;
@@ -31,13 +32,15 @@ The installer:
 2. installs Bun/dependencies as needed;
 3. creates private owner auth configuration when missing;
 4. runs the production build;
-5. installs the `mso.service` system unit when systemd is available;
-6. enables the owner's lingering user manager needed by self-update/managed-app user units;
-7. installs `~/.local/bin/mso` plus a guarded `/usr/local/bin/mso` launcher so the parent
-   shell can resolve `mso` immediately after `curl | bash` returns;
-8. persists an idempotent `~/.local/bin` PATH fallback for future shells;
-9. starts/replaces the service only after a successful build;
-10. on a fresh interactive install, opens `/dev/tty` and launches `mso onboard`.
+5. installs `~/.local/bin/mso` **before service setup**, then attempts a guarded launcher in
+   `/usr/local/bin` when that directory is already on the invoking shell's PATH;
+6. verifies whether the invoking shell will actually resolve `mso` after the child installer
+   returns, and persists an idempotent `~/.local/bin` PATH fallback for future shells;
+7. installs the `mso.service` system unit only when systemd is really PID 1 (not merely when a
+   `systemctl` executable exists);
+8. enables the owner's lingering user manager needed by self-update/managed-app user units;
+9. activates the service only after a successful build;
+10. on a fresh interactive install with a verified running service, opens `/dev/tty` and launches `mso onboard`.
 
 Useful flags:
 
@@ -82,6 +85,26 @@ Hermes/OpenClaw installation is optional and uses each app's existing managed-jo
 Their model/provider configuration belongs to those applications and is not implicitly
 filled from Alfa's credential. Selected app installs stream their job transcript until a
 terminal status.
+
+### WSL2
+
+WSL can contain `systemctl` while still running a non-systemd PID 1. MSO treats those as two
+different capabilities: the CLI is installed normally, while the background service is skipped
+with an explicit message. This prevents service setup from aborting before `mso` exists.
+
+For the full service on WSL2, enable systemd in `/etc/wsl.conf`:
+
+```ini
+[boot]
+systemd=true
+```
+
+Then exit all WSL sessions from Windows, reopen the distro, confirm `ps -p 1 -o comm=` reports
+`systemd`, and re-run the installer. The installer never edits WSL host configuration itself.
+
+If the installer reports that the current shell did not already contain a reachable launcher
+directory, use the exact PATH command it prints for that shell; the profile change is already
+persisted for future shells.
 
 ## 2. Network exposure
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -17,13 +17,17 @@ already-reachable system bin directory when possible. It checks the original inv
 than its child-process PATH and prints an exact fallback export when immediate discovery cannot be
 proven. WSL without systemd remains a supported CLI-only shape; background service/onboarding waits
 for a verified service. An isolated clean-HOME/PATH install proved the child installer returns to a
-parent shell where `command -v mso` and `mso -h` succeed.
+parent shell where `command -v mso` and `mso -h` succeed. The invoking cwd is captured too: relative
+PATH entries such as `bin` are normalized against that cwd before discoverability is claimed, so a
+later `cd` into the checkout cannot manufacture a false positive.
 
 The service readiness gate was also corrected for explicit `NEXT_DEPLOYMENT_ID`. Build ID change is
 still the preferred takeover proof, but a deliberately stable deployment ID can no longer make a
 healthy restart look stale: the installer records the pre-restart systemd MainPID and accepts a
 healthy response from a changed live MainPID as the fallback proof. This keeps the old-process/stale-
-chunk defense without assuming every deployment changes its public build ID.
+chunk defense without assuming every deployment changes its public build ID. Runtime reporting also
+distinguishes “WSL without systemd” from “systemd existed, the unit was attempted, but health/takeover
+verification failed,” so a failed WSL service keeps its journal recovery path instead of being mislabeled.
 
 OpenSSF's remaining Fuzzing posture gap is addressed with real TypeScript property testing rather
 than a dismissed alert. `fast-check` now generates adversarial cases for filesystem containment,

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,41 @@
 
 Running log of what shipped each phase. Newest at top.
 
+## 2026-08-30 — WSL installer reliability and recognized property fuzzing (SHIPPED)
+
+A WSL install exposed two assumptions that were true on the production VPS but not on a fresh
+Linux shell. The installer treated the presence of a `systemctl` executable as proof that systemd
+was PID 1, and it did service setup before creating the CLI launchers. On WSL with systemd disabled,
+`systemctl` therefore aborted the `set -e` installer before `mso` existed. Separately, `curl | bash`
+can never modify the parent shell's PATH, so claiming `mso -h` was immediately available without
+checking the invoking PATH was not a valid installation contract.
+
+The installer now creates and validates the CLI before service setup, requires systemd to actually
+be PID 1, persists `~/.local/bin` for future bash/zsh sessions, and uses a guarded launcher in an
+already-reachable system bin directory when possible. It checks the original invoking PATH rather
+than its child-process PATH and prints an exact fallback export when immediate discovery cannot be
+proven. WSL without systemd remains a supported CLI-only shape; background service/onboarding waits
+for a verified service. An isolated clean-HOME/PATH install proved the child installer returns to a
+parent shell where `command -v mso` and `mso -h` succeed.
+
+The service readiness gate was also corrected for explicit `NEXT_DEPLOYMENT_ID`. Build ID change is
+still the preferred takeover proof, but a deliberately stable deployment ID can no longer make a
+healthy restart look stale: the installer records the pre-restart systemd MainPID and accepts a
+healthy response from a changed live MainPID as the fallback proof. This keeps the old-process/stale-
+chunk defense without assuming every deployment changes its public build ID.
+
+OpenSSF's remaining Fuzzing posture gap is addressed with real TypeScript property testing rather
+than a dismissed alert. `fast-check` now generates adversarial cases for filesystem containment,
+private-provider SSRF rejection, and PKCE exactness; the package/import form is one that Scorecard's
+Fuzzing check recognizes. Code Review and CII Best Practices remain external governance evidence:
+they require genuine independent review and OpenSSF badge enrollment rather than repository-side
+alert suppression.
+
+Verification: installer Bash syntax + hosted ShellCheck, installer contract tests, hundreds of
+property-generated security cases, full TypeScript/lint/test gates, docs/changelog parity, dependency
+audit, isolated production build, an isolated clean-HOME/PATH install, and protected-branch hosted
+CodeQL/dependency/Gitleaks/Trivy/OSV/Semgrep checks.
+
 > **How to read this log:** it is the source of truth for **why/when work shipped**, not
 > today's API/runbook. Phases 0–14 were built on **Convex self-hosted + a Control-Room
 > host-agent bridge**; that stack was removed in Phase 15 and later entries describe the

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -21,11 +21,12 @@ parent shell where `command -v mso` and `mso -h` succeed. The invoking cwd is ca
 PATH entries such as `bin` are normalized against that cwd before discoverability is claimed, so a
 later `cd` into the checkout cannot manufacture a false positive.
 
-The service readiness gate was also corrected for explicit `NEXT_DEPLOYMENT_ID`. Build ID change is
-still the preferred takeover proof, but a deliberately stable deployment ID can no longer make a
-healthy restart look stale: the installer records the pre-restart systemd MainPID and accepts a
-healthy response from a changed live MainPID as the fallback proof. This keeps the old-process/stale-
-chunk defense without assuming every deployment changes its public build ID. Runtime reporting also
+The service readiness gate was also corrected for explicit `NEXT_DEPLOYMENT_ID`. Each installer-
+driven service restart now receives a fresh random runtime instance ID in the systemd unit, and the
+public no-store health route echoes that non-secret value. Readiness accepts the response only when
+it carries the exact freshly injected ID. This is stronger than either build-ID or MainPID change:
+it still works when the deployment ID intentionally stays stable, while a stale or unrelated process
+that happens to answer on the same port cannot satisfy the gate. Runtime reporting also
 distinguishes “WSL without systemd” from “systemd existed, the unit was attempted, but health/takeover
 verification failed,” so a failed WSL service keeps its journal recovery path instead of being mislabeled.
 

--- a/lib/config/env-example.test.ts
+++ b/lib/config/env-example.test.ts
@@ -21,6 +21,7 @@ const NOT_A_KNOB: Record<string, string> = {
   // Injected by the framework or the runtime.
   NEXT_RUNTIME: "set by Next itself",
   NEXT_PUBLIC_BUILD_ID: "injected by next.config.mjs at build time",
+  MSO_RUNTIME_INSTANCE_ID: "injected by the installer-managed service to prove restart readiness",
   VITEST: "set by the test runner",
   // The OS gives these to every process.
   SHELL: "the OS's",

--- a/lib/install-contract.test.ts
+++ b/lib/install-contract.test.ts
@@ -40,6 +40,8 @@ describe("one-line installer contract", () => {
     expect(src).toContain('= "systemd"');
     expect(src).toContain("WSL detected without systemd as PID 1");
     expect(src).toContain("SERVICE_READY=1");
+    expect(src).toContain('systemctl show "$SERVICE" -p MainPID --value');
+    expect(src).toContain('[ "$now_pid" -gt 0 ] && [ "$now_pid" != "$prev_pid" ]');
     expect(src).toContain('[ "$RUN_ONBOARD" -eq 1 ] && [ "$SERVICE_READY" -eq 1 ]');
   });
 

--- a/lib/install-contract.test.ts
+++ b/lib/install-contract.test.ts
@@ -22,12 +22,25 @@ describe("one-line installer contract", () => {
     expect(src).toContain('FRESH_INSTALL=1');
   });
 
-  it("makes mso discoverable immediately and persists the user PATH fallback", () => {
+  it("installs the CLI before service setup and proves it against the invoking PATH", () => {
     const src = fs.readFileSync(INSTALL, "utf8");
-    expect(src).toContain("SYSTEM_CLI=/usr/local/bin/mso");
+    expect(src.indexOf("# ---- CLI on PATH")).toBeLessThan(src.indexOf("# ---- systemd unit ----"));
+    expect(src).toContain('PARENT_PATH="${PATH:-}"');
+    expect(src).toContain('SYSTEM_BIN_DIR="${MSO_SYSTEM_BIN_DIR:-/usr/local/bin}"');
+    expect(src).toContain('PATH="$PARENT_PATH" command -v mso');
+    expect(src).toContain('"$BIN_DIR/mso" -h');
     expect(src).toContain("# >>> mso cli >>>");
     expect(src).toContain('export PATH="$BIN_DIR:$PATH"');
-    expect(src).toContain('command -v mso');
+  });
+
+  it("requires systemd as PID 1 before service setup and gates onboarding on verified health", () => {
+    const src = fs.readFileSync(INSTALL, "utf8");
+    expect(src).toContain("systemd_ready()");
+    expect(src).toContain("/proc/1/comm");
+    expect(src).toContain('= "systemd"');
+    expect(src).toContain("WSL detected without systemd as PID 1");
+    expect(src).toContain("SERVICE_READY=1");
+    expect(src).toContain('[ "$RUN_ONBOARD" -eq 1 ] && [ "$SERVICE_READY" -eq 1 ]');
   });
 
   it("verifies a commit-pinned Bun bootstrap before execution", () => {

--- a/lib/install-contract.test.ts
+++ b/lib/install-contract.test.ts
@@ -26,8 +26,11 @@ describe("one-line installer contract", () => {
     const src = fs.readFileSync(INSTALL, "utf8");
     expect(src.indexOf("# ---- CLI on PATH")).toBeLessThan(src.indexOf("# ---- systemd unit ----"));
     expect(src).toContain('PARENT_PATH="${PATH:-}"');
+    expect(src).toContain('PARENT_CWD="$PWD"');
+    expect(src).toContain('normalize_parent_path()');
+    expect(src).toContain('PARENT_PATH_RESOLVED="$(normalize_parent_path "$PARENT_PATH" "$PARENT_CWD")"');
     expect(src).toContain('SYSTEM_BIN_DIR="${MSO_SYSTEM_BIN_DIR:-/usr/local/bin}"');
-    expect(src).toContain('PATH="$PARENT_PATH" command -v mso');
+    expect(src).toContain('PATH="$PARENT_PATH_RESOLVED" command -v mso');
     expect(src).toContain('"$BIN_DIR/mso" -h');
     expect(src).toContain("# >>> mso cli >>>");
     expect(src).toContain('export PATH="$BIN_DIR:$PATH"');
@@ -40,6 +43,9 @@ describe("one-line installer contract", () => {
     expect(src).toContain('= "systemd"');
     expect(src).toContain("WSL detected without systemd as PID 1");
     expect(src).toContain("SERVICE_READY=1");
+    expect(src).toContain("SERVICE_ATTEMPTED=1");
+    expect(src).toContain('elif [ "$SERVICE_ATTEMPTED" -eq 1 ]; then');
+    expect(src.indexOf('elif [ "$SERVICE_ATTEMPTED" -eq 1 ]; then')).toBeLessThan(src.indexOf('elif is_wsl; then'));
     expect(src).toContain('systemctl show "$SERVICE" -p MainPID --value');
     expect(src).toContain('[ "$now_pid" -gt 0 ] && [ "$now_pid" != "$prev_pid" ]');
     expect(src).toContain('[ "$RUN_ONBOARD" -eq 1 ] && [ "$SERVICE_READY" -eq 1 ]');

--- a/lib/install-contract.test.ts
+++ b/lib/install-contract.test.ts
@@ -34,6 +34,7 @@ describe("one-line installer contract", () => {
     expect(src).toContain('"$BIN_DIR/mso" -h');
     expect(src).toContain("# >>> mso cli >>>");
     expect(src).toContain('export PATH="$BIN_DIR:$PATH"');
+    expect(src).toContain('custom MSO_BIN_DIR is not persisted automatically');
   });
 
   it("requires systemd as PID 1 before service setup and gates onboarding on verified health", () => {
@@ -46,8 +47,9 @@ describe("one-line installer contract", () => {
     expect(src).toContain("SERVICE_ATTEMPTED=1");
     expect(src).toContain('elif [ "$SERVICE_ATTEMPTED" -eq 1 ]; then');
     expect(src.indexOf('elif [ "$SERVICE_ATTEMPTED" -eq 1 ]; then')).toBeLessThan(src.indexOf('elif is_wsl; then'));
-    expect(src).toContain('systemctl show "$SERVICE" -p MainPID --value');
-    expect(src).toContain('[ "$now_pid" -gt 0 ] && [ "$now_pid" != "$prev_pid" ]');
+    expect(src).toContain('RUNTIME_INSTANCE_ID="$(rand_hex 16)"');
+    expect(src).toContain('Environment=MSO_RUNTIME_INSTANCE_ID=$RUNTIME_INSTANCE_ID');
+    expect(src).toContain('[ "$now_instance" = "$RUNTIME_INSTANCE_ID" ]');
     expect(src).toContain('[ "$RUN_ONBOARD" -eq 1 ] && [ "$SERVICE_READY" -eq 1 ]');
   });
 

--- a/lib/security/property-fuzz.test.ts
+++ b/lib/security/property-fuzz.test.ts
@@ -1,0 +1,70 @@
+import path from "node:path";
+import * as fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { isUnderRoot } from "@/lib/host/paths";
+import { assertSafeUrl, isForbiddenProviderAddress } from "@/lib/host/ssrf";
+import { safeEqualHex, sha256b64url, verifyPkce } from "@/lib/mcp/pkce";
+
+const segmentChar = fc.constantFrom(..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-");
+const segment = fc.array(segmentChar, { minLength: 1, maxLength: 18 }).map((chars) => chars.join(""));
+const octet = fc.integer({ min: 0, max: 255 });
+const verifierChar = fc.constantFrom(..."ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~");
+const verifier = fc.array(verifierChar, { minLength: 43, maxLength: 128 }).map((chars) => chars.join(""));
+
+function changedSameLength(value: string): string {
+  const first = value[0] === "A" ? "B" : "A";
+  return first + value.slice(1);
+}
+
+describe("property fuzz — security boundaries", () => {
+  it("keeps generated descendants inside a root and generated siblings outside it", () => {
+    const root = path.resolve("/tmp/mso-property-root");
+    fc.assert(
+      fc.property(fc.array(segment, { minLength: 1, maxLength: 8 }), segment, (parts, siblingName) => {
+        const inside = path.join(root, ...parts);
+        const outside = path.join(path.dirname(root), `outside-${siblingName}`);
+        expect(isUnderRoot(inside, root)).toBe(true);
+        expect(isUnderRoot(outside, root)).toBe(false);
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  it("rejects generated RFC1918 and loopback IPv4 provider addresses", () => {
+    fc.assert(
+      fc.property(octet, octet, octet, fc.integer({ min: 16, max: 31 }), (a, b, c, private172) => {
+        const addresses = [
+          `10.${a}.${b}.${c}`,
+          `127.${a}.${b}.${c}`,
+          `192.168.${a}.${b}`,
+          `172.${private172}.${a}.${b}`,
+        ];
+        for (const address of addresses) expect(isForbiddenProviderAddress(address)).toBe(true);
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  it("never accepts a generated private literal as a provider URL", () => {
+    fc.assert(
+      fc.property(octet, octet, octet, (a, b, c) => {
+        expect(() => assertSafeUrl(`https://10.${a}.${b}.${c}/v1`)).toThrow(/not allowed/i);
+        expect(() => assertSafeUrl(`https://127.${a}.${b}.${c}/v1`)).toThrow(/not allowed/i);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("keeps PKCE verification exact across generated RFC7636 verifiers", () => {
+    fc.assert(
+      fc.property(verifier, (value) => {
+        const challenge = sha256b64url(value);
+        expect(verifyPkce(value, challenge, "S256")).toBe(true);
+        expect(verifyPkce(value, changedSameLength(challenge), "S256")).toBe(false);
+        expect(safeEqualHex(challenge, challenge)).toBe(true);
+        expect(safeEqualHex(challenge, changedSameLength(challenge))).toBe(false);
+      }),
+      { numRuns: 300 },
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@vitest/coverage-v8": "^4.1.11",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.3.2",
+    "fast-check": "^4.9.0",
     "postcss": "^8.5.26",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -435,11 +435,14 @@ EOF
   HEALTH_HOST="$BIND"
   case "$BIND" in 0.0.0.0|::|"") HEALTH_HOST=127.0.0.1 ;; esac
 
-  # Read the id of the build that is CURRENTLY answering, before we touch the
-  # unit. Every build gets a fresh NEXT_PUBLIC_BUILD_ID (next.config.mjs), so a
-  # changed id is what proves the new process took over.
+  # Record BOTH the build id and service PID that are CURRENTLY answering before
+  # the restart. Normally next.config.mjs mints a fresh build id, but an explicit
+  # NEXT_DEPLOYMENT_ID intentionally makes that id stable across deploys. In that
+  # supported mode, a changed MainPID plus a healthy response proves takeover.
   prev_build="$(curl -fsS --max-time 3 "http://$HEALTH_HOST:$PORT/api/health" 2>/dev/null \
                 | sed -n 's/.*"buildId":"\([^"]*\)".*/\1/p' || true)"
+  prev_pid="$(systemctl show "$SERVICE" -p MainPID --value 2>/dev/null || true)"
+  case "$prev_pid" in ''|*[!0-9]*) prev_pid=0 ;; esac
 
   # Makes /run/user/<uid> — where the user bus lives — exist without a login
   # session and survive logout. The XDG_RUNTIME_DIR above names that directory, so
@@ -474,11 +477,18 @@ EOF
     body="$(curl -fsS --max-time 3 "http://$HEALTH_HOST:$PORT/api/health" 2>/dev/null || true)"
     if [ -n "$body" ]; then
       now_build="$(printf '%s' "$body" | sed -n 's/.*"buildId":"\([^"]*\)".*/\1/p')"
-      # Gate on the id, not on curl's exit status: the old process answers
-      # /api/health perfectly while serving stale chunks, which is exactly how
-      # a failed update used to report "health OK".
-      if [ -z "$prev_build" ] || [ "$now_build" != "$prev_build" ]; then
-        up=1; SERVICE_READY=1; ok "health OK (build ${now_build:-unknown})"; break
+      # Do not trust curl alone: the OLD process can answer /api/health while
+      # serving stale chunks. Prefer a changed build id; when a configured
+      # deployment id keeps it stable, require systemd to report a different
+      # live MainPID. Fresh installs have no previous healthy build and pass.
+      now_pid="$(systemctl show "$SERVICE" -p MainPID --value 2>/dev/null || true)"
+      case "$now_pid" in ''|*[!0-9]*) now_pid=0 ;; esac
+      if [ -z "$prev_build" ] \
+        || [ "$now_build" != "$prev_build" ] \
+        || { [ "$now_pid" -gt 0 ] && [ "$now_pid" != "$prev_pid" ]; }; then
+        up=1; SERVICE_READY=1
+        ok "health OK (build ${now_build:-unknown}, pid ${now_pid:-unknown})"
+        break
       fi
     fi
     sleep 2
@@ -486,7 +496,7 @@ EOF
   if [ "$up" -ne 1 ]; then
     # is-active needs no privileges — do not spend a sudo prompt on the sad path.
     if systemctl is-active --quiet "$SERVICE"; then
-      warn "service is running but still serving build $prev_build — check: journalctl -u mso -e"
+      warn "service is running but build/process identity did not change (build $prev_build, pid $prev_pid) — check: journalctl -u mso -e"
     else
       warn "$SERVICE is not running — check: journalctl -u mso -e"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -581,7 +581,7 @@ cat <<EOF
   Logs:     $LOG_STATUS
   Update:   re-run this installer (pull + verify + build + service refresh), or --uninstall to remove
   Listen:   $BIND:$PORT   (change with --bind / MSO_BIND)
-  Security: verify from OUTSIDE the box — `curl -m5 http://<public-ip>:$PORT/api/health`
+  Security: verify from OUTSIDE the box — \`curl -m5 http://<public-ip>:$PORT/api/health\`
             run on your laptop is the only test that proves what is reachable.
             Review ~/.mso/audit.log.
 EOF

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,7 +41,9 @@ export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
 # curl|bash process cannot export back into its parent, so this is the only PATH
 # that matters when proving `mso -h` will resolve immediately after we return.
 PARENT_PATH="${PATH:-}"
+PARENT_CWD="$PWD"
 SERVICE_READY=0
+SERVICE_ATTEMPTED=0
 # Reproducible bootstrap: this is Bun v1.3.14's installer source, pinned by
 # immutable Git commit and verified before execution. Update both values together.
 BUN_BOOTSTRAP_COMMIT="0d9b296af33f2b851fcbf4df3e9ec89751734ba4"
@@ -109,6 +111,27 @@ systemd_ready() {
 
 path_has_dir() {
   case ":$1:" in *":$2:"*) return 0 ;; *) return 1 ;; esac
+}
+
+# PATH entries are resolved by the caller relative to the caller's cwd. The
+# installer later cd's into the checkout, so replaying a raw relative PATH there
+# would prove the wrong shell. Convert each entry to the directory the parent
+# shell will actually search after this child returns. Empty entries mean cwd.
+normalize_parent_path() {
+  local raw="$1" cwd="$2" out="" entry last=0
+  while [ "$last" -eq 0 ]; do
+    case "$raw" in
+      *:*) entry="${raw%%:*}"; raw="${raw#*:}" ;;
+      *) entry="$raw"; raw=""; last=1 ;;
+    esac
+    case "$entry" in
+      "") entry="$cwd" ;;
+      /*) ;;
+      *) entry="$cwd/$entry" ;;
+    esac
+    if [ -n "$out" ]; then out="$out:$entry"; else out="$entry"; fi
+  done
+  printf '%s' "$out"
 }
 
 # Create/update one CLI symlink without ever replacing an unrelated command.
@@ -347,17 +370,19 @@ fi
 # directory was already there, nothing else is needed. Otherwise use a guarded
 # launcher in /usr/local/bin (or MSO_SYSTEM_BIN_DIR) only when that directory is
 # already on the invoking PATH. This also makes `--no-service` useful on WSL.
+PARENT_PATH_RESOLVED="$(normalize_parent_path "$PARENT_PATH" "$PARENT_CWD")"
 SYSTEM_BIN_DIR="${MSO_SYSTEM_BIN_DIR:-/usr/local/bin}"
+case "$SYSTEM_BIN_DIR" in /*) ;; *) SYSTEM_BIN_DIR="$PARENT_CWD/$SYSTEM_BIN_DIR" ;; esac
 SYSTEM_CLI="$SYSTEM_BIN_DIR/mso"
 TARGET_CLI_REAL="$(readlink -f "$DIR/bin/mso")"
 CLI_IMMEDIATE=0
-parent_cli="$(PATH="$PARENT_PATH" command -v mso 2>/dev/null || true)"
+parent_cli="$(PATH="$PARENT_PATH_RESOLVED" command -v mso 2>/dev/null || true)"
 if [ -n "$parent_cli" ] && [ "$(readlink -f "$parent_cli" 2>/dev/null || true)" = "$TARGET_CLI_REAL" ]; then
   CLI_IMMEDIATE=1
-elif path_has_dir "$PARENT_PATH" "$SYSTEM_BIN_DIR"; then
+elif path_has_dir "$PARENT_PATH_RESOLVED" "$SYSTEM_BIN_DIR"; then
   if link_cli_guarded "$SYSTEM_CLI" "$DIR/bin/mso"; then
     ok "current-PATH cli → $SYSTEM_CLI"
-    parent_cli="$(PATH="$PARENT_PATH" command -v mso 2>/dev/null || true)"
+    parent_cli="$(PATH="$PARENT_PATH_RESOLVED" command -v mso 2>/dev/null || true)"
     if [ -n "$parent_cli" ] && [ "$(readlink -f "$parent_cli" 2>/dev/null || true)" = "$TARGET_CLI_REAL" ]; then
       CLI_IMMEDIATE=1
     fi
@@ -383,6 +408,7 @@ fi
 
 # ---- systemd unit ----
 if [ "$DO_SERVICE" -eq 1 ] && systemd_ready; then
+  SERVICE_ATTEMPTED=1
   # Start via npm (always on PATH, ships with node) to match the proven prod unit;
   # PORT/HOSTNAME are set as env too so `next start` binds correctly regardless.
   NPM_BIN="$(command -v npm)"
@@ -564,12 +590,15 @@ if [ "$SERVICE_READY" -eq 1 ]; then
 elif [ "$DO_SERVICE" -eq 0 ]; then
   OPEN_STATUS="not running (--no-service). Start manually: cd $DIR && PORT=$PORT bun run start"
   LOG_STATUS="no system service installed"
+elif [ "$SERVICE_ATTEMPTED" -eq 1 ]; then
+  OPEN_STATUS="service was installed/restarted but did not pass health verification; inspect the journal before opening the UI"
+  LOG_STATUS="journalctl -u mso -e"
 elif is_wsl; then
   OPEN_STATUS="not running (WSL systemd is unavailable). Enable systemd or start manually from $DIR"
   LOG_STATUS="no system service installed"
 else
-  OPEN_STATUS="service did not pass health verification; inspect the service journal before opening the UI"
-  LOG_STATUS="journalctl -u mso -e"
+  OPEN_STATUS="systemd is unavailable; start manually from $DIR"
+  LOG_STATUS="no system service installed"
 fi
 
 ok "mso installed at $DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -403,7 +403,11 @@ if [ "$CLI_IMMEDIATE" -eq 1 ]; then
 else
   warn "mso is installed, but this shell's existing PATH cannot see it yet"
   warn "for this shell run: export PATH=\"$BIN_DIR:\$PATH\""
-  info "future shells will load the persisted ~/.local/bin PATH block"
+  if [ "$BIN_DIR" = "$HOME/.local/bin" ]; then
+    info "future shells will load the persisted ~/.local/bin PATH block"
+  else
+    warn "custom MSO_BIN_DIR is not persisted automatically; add $BIN_DIR to your shell profile"
+  fi
 fi
 
 # ---- systemd unit ----
@@ -412,6 +416,7 @@ if [ "$DO_SERVICE" -eq 1 ] && systemd_ready; then
   # Start via npm (always on PATH, ships with node) to match the proven prod unit;
   # PORT/HOSTNAME are set as env too so `next start` binds correctly regardless.
   NPM_BIN="$(command -v npm)"
+  RUNTIME_INSTANCE_ID="$(rand_hex 16)"
   info "installing $SERVICE (needs sudo)…"
   sudo_do tee "/etc/systemd/system/$SERVICE" >/dev/null <<EOF
 [Unit]
@@ -425,6 +430,10 @@ WorkingDirectory=$DIR
 EnvironmentFile=$DIR/.env.local
 Environment=PORT=$PORT
 Environment=HOSTNAME=$BIND
+# Fresh on every installer-driven restart. /api/health echoes this non-secret nonce
+# so readiness proves the HTTP response came from THIS restarted unit, not a stale
+# process that happened to keep answering on the configured port.
+Environment=MSO_RUNTIME_INSTANCE_ID=$RUNTIME_INSTANCE_ID
 # A system unit with User= inherits no login session, so it gets no user-bus
 # address and every \`systemctl --user\` it runs answers "Failed to connect to bus:
 # No medium found". That silently broke the managed-app installs (which create
@@ -461,15 +470,6 @@ EOF
   HEALTH_HOST="$BIND"
   case "$BIND" in 0.0.0.0|::|"") HEALTH_HOST=127.0.0.1 ;; esac
 
-  # Record BOTH the build id and service PID that are CURRENTLY answering before
-  # the restart. Normally next.config.mjs mints a fresh build id, but an explicit
-  # NEXT_DEPLOYMENT_ID intentionally makes that id stable across deploys. In that
-  # supported mode, a changed MainPID plus a healthy response proves takeover.
-  prev_build="$(curl -fsS --max-time 3 "http://$HEALTH_HOST:$PORT/api/health" 2>/dev/null \
-                | sed -n 's/.*"buildId":"\([^"]*\)".*/\1/p' || true)"
-  prev_pid="$(systemctl show "$SERVICE" -p MainPID --value 2>/dev/null || true)"
-  case "$prev_pid" in ''|*[!0-9]*) prev_pid=0 ;; esac
-
   # Makes /run/user/<uid> — where the user bus lives — exist without a login
   # session and survive logout. The XDG_RUNTIME_DIR above names that directory, so
   # without linger it would point at nothing after the installing shell exits.
@@ -503,17 +503,14 @@ EOF
     body="$(curl -fsS --max-time 3 "http://$HEALTH_HOST:$PORT/api/health" 2>/dev/null || true)"
     if [ -n "$body" ]; then
       now_build="$(printf '%s' "$body" | sed -n 's/.*"buildId":"\([^"]*\)".*/\1/p')"
-      # Do not trust curl alone: the OLD process can answer /api/health while
-      # serving stale chunks. Prefer a changed build id; when a configured
-      # deployment id keeps it stable, require systemd to report a different
-      # live MainPID. Fresh installs have no previous healthy build and pass.
-      now_pid="$(systemctl show "$SERVICE" -p MainPID --value 2>/dev/null || true)"
-      case "$now_pid" in ''|*[!0-9]*) now_pid=0 ;; esac
-      if [ -z "$prev_build" ] \
-        || [ "$now_build" != "$prev_build" ] \
-        || { [ "$now_pid" -gt 0 ] && [ "$now_pid" != "$prev_pid" ]; }; then
+      now_instance="$(printf '%s' "$body" | sed -n 's/.*"runtimeInstanceId":"\([^"]*\)".*/\1/p')"
+      # A healthy response is accepted only when it carries the nonce injected into
+      # THIS service unit before restart. This remains correct when NEXT_DEPLOYMENT_ID
+      # intentionally keeps buildId stable and cannot be satisfied by a stale or
+      # unrelated process still listening on the same port.
+      if [ "$now_instance" = "$RUNTIME_INSTANCE_ID" ]; then
         up=1; SERVICE_READY=1
-        ok "health OK (build ${now_build:-unknown}, pid ${now_pid:-unknown})"
+        ok "health OK (build ${now_build:-unknown}, runtime instance verified)"
         break
       fi
     fi
@@ -522,7 +519,7 @@ EOF
   if [ "$up" -ne 1 ]; then
     # is-active needs no privileges — do not spend a sudo prompt on the sad path.
     if systemctl is-active --quiet "$SERVICE"; then
-      warn "service is running but build/process identity did not change (build $prev_build, pid $prev_pid) — check: journalctl -u mso -e"
+      warn "service is running but /api/health did not prove the restarted runtime instance — check: journalctl -u mso -e"
     else
       warn "$SERVICE is not running — check: journalctl -u mso -e"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,6 +37,11 @@ ONBOARD_MODE=auto
 FRESH_INSTALL=0
 # bun is the package manager; the RUNTIME stays node (see ensure_bun below).
 export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+# Capture the INVOKING shell PATH before Bun or the installer changes it. A child
+# curl|bash process cannot export back into its parent, so this is the only PATH
+# that matters when proving `mso -h` will resolve immediately after we return.
+PARENT_PATH="${PATH:-}"
+SERVICE_READY=0
 # Reproducible bootstrap: this is Bun v1.3.14's installer source, pinned by
 # immutable Git commit and verified before execution. Update both values together.
 BUN_BOOTSTRAP_COMMIT="0d9b296af33f2b851fcbf4df3e9ec89751734ba4"
@@ -92,9 +97,50 @@ done
 
 sudo_do() { if command -v sudo >/dev/null 2>&1; then sudo "$@"; else die "need root for: $* (install sudo or run the step by hand)"; fi; }
 
+is_wsl() {
+  grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null || grep -qi microsoft /proc/version 2>/dev/null
+}
+
+systemd_ready() {
+  command -v systemctl >/dev/null 2>&1 || return 1
+  [ -r /proc/1/comm ] || return 1
+  [ "$(tr -d '\n' </proc/1/comm 2>/dev/null)" = "systemd" ]
+}
+
+path_has_dir() {
+  case ":$1:" in *":$2:"*) return 0 ;; *) return 1 ;; esac
+}
+
+# Create/update one CLI symlink without ever replacing an unrelated command.
+# Returns nonzero when the destination is unavailable; callers decide whether that
+# is fatal (the user-local launcher is) or only affects current-shell discovery.
+link_cli_guarded() {
+  local link="$1" target="$2" current dir
+  dir="$(dirname "$link")"
+  [ -d "$dir" ] || return 1
+  if [ -e "$link" ] && [ ! -L "$link" ]; then
+    warn "$link already exists and is not a symlink — left untouched"
+    return 1
+  fi
+  if [ -L "$link" ]; then
+    current="$(readlink "$link")"
+    case "$current" in
+      "$DIR/"*) ;;
+      *) warn "$link already points elsewhere ($current) — left untouched"; return 1 ;;
+    esac
+  fi
+  if [ -w "$dir" ]; then
+    ln -sfn "$target" "$link"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo ln -sfn "$target" "$link" || return 1
+  else
+    return 1
+  fi
+}
+
 # If a service already exists, update IT in place (unless --dir was given) — so a
 # re-run never spins up a divergent second copy next to a working install.
-if [ "$DIR_EXPLICIT" -eq 0 ] && command -v systemctl >/dev/null 2>&1; then
+if [ "$DIR_EXPLICIT" -eq 0 ] && systemd_ready; then
   existing="$(systemctl show -p WorkingDirectory --value "$SERVICE" 2>/dev/null || true)"
   [ -n "$existing" ] && [ -d "$existing/.git" ] && DIR="$existing" && info "found existing service → updating $DIR"
 fi
@@ -120,8 +166,11 @@ if [ "$DO_UNINSTALL" -eq 1 ]; then
   if [ -L "$UNINST_BIN" ] && case "$(readlink "$UNINST_BIN")" in "$DIR/"*) true ;; *) false ;; esac; then
     rm -f "$UNINST_BIN"; ok "removed cli symlink $UNINST_BIN"
   fi
-  if [ -L /usr/local/bin/mso ] && case "$(readlink /usr/local/bin/mso)" in "$DIR/"*) true ;; *) false ;; esac; then
-    sudo_do rm -f /usr/local/bin/mso; ok "removed cli symlink /usr/local/bin/mso"
+  UNINST_SYSTEM_CLI="${MSO_SYSTEM_BIN_DIR:-/usr/local/bin}/mso"
+  if [ -L "$UNINST_SYSTEM_CLI" ] && case "$(readlink "$UNINST_SYSTEM_CLI")" in "$DIR/"*) true ;; *) false ;; esac; then
+    if [ -w "$(dirname "$UNINST_SYSTEM_CLI")" ]; then rm -f "$UNINST_SYSTEM_CLI"
+    else sudo_do rm -f "$UNINST_SYSTEM_CLI"; fi
+    ok "removed cli symlink $UNINST_SYSTEM_CLI"
   fi
   UNINST_SKILLS="${MSO_SKILL_DIR:-$HOME/.claude/skills}"
   if [ -d "$UNINST_SKILLS" ]; then
@@ -259,8 +308,81 @@ fi
 info "building (next build)…"
 bun run build
 
+# ---- CLI on PATH (before service setup so WSL/no-systemd still gets a CLI) ----
+# The web UI is one frontend; bin/mso reaches the same /api surface from a shell.
+BIN_DIR="${MSO_BIN_DIR:-$HOME/.local/bin}"
+mkdir -p "$BIN_DIR"
+ln -sfn "$DIR/bin/mso" "$BIN_DIR/mso"
+ok "cli → $BIN_DIR/mso"
+
+# A fresh distro/WSL home often omits ~/.local/bin from the current PATH. Persist
+# one small idempotent block for future shells. Default to bash when SHELL is not
+# exported (common in curl|bash/cloud-init); zsh gets its own rc instead.
+path_block() {
+  local rc="$1"
+  [ -e "$rc" ] || : > "$rc"
+  grep -q '^# >>> mso cli >>>$' "$rc" 2>/dev/null && return
+  cat >> "$rc" <<'EOF'
+
+# >>> mso cli >>>
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+# <<< mso cli <<<
+EOF
+  info "added ~/.local/bin to PATH in $rc"
+}
+if [ "$BIN_DIR" = "$HOME/.local/bin" ]; then
+  path_block "$HOME/.profile"
+  case "${SHELL:-/bin/bash}" in
+    */zsh) path_block "$HOME/.zshrc" ;;
+    *)     path_block "$HOME/.bashrc" ;;
+  esac
+else
+  warn "custom MSO_BIN_DIR=$BIN_DIR is not written into shell profiles; add it to PATH yourself"
+fi
+
+# Prove discoverability from the PARENT shell's original PATH. If the user-local
+# directory was already there, nothing else is needed. Otherwise use a guarded
+# launcher in /usr/local/bin (or MSO_SYSTEM_BIN_DIR) only when that directory is
+# already on the invoking PATH. This also makes `--no-service` useful on WSL.
+SYSTEM_BIN_DIR="${MSO_SYSTEM_BIN_DIR:-/usr/local/bin}"
+SYSTEM_CLI="$SYSTEM_BIN_DIR/mso"
+TARGET_CLI_REAL="$(readlink -f "$DIR/bin/mso")"
+CLI_IMMEDIATE=0
+parent_cli="$(PATH="$PARENT_PATH" command -v mso 2>/dev/null || true)"
+if [ -n "$parent_cli" ] && [ "$(readlink -f "$parent_cli" 2>/dev/null || true)" = "$TARGET_CLI_REAL" ]; then
+  CLI_IMMEDIATE=1
+elif path_has_dir "$PARENT_PATH" "$SYSTEM_BIN_DIR"; then
+  if link_cli_guarded "$SYSTEM_CLI" "$DIR/bin/mso"; then
+    ok "current-PATH cli → $SYSTEM_CLI"
+    parent_cli="$(PATH="$PARENT_PATH" command -v mso 2>/dev/null || true)"
+    if [ -n "$parent_cli" ] && [ "$(readlink -f "$parent_cli" 2>/dev/null || true)" = "$TARGET_CLI_REAL" ]; then
+      CLI_IMMEDIATE=1
+    fi
+  else
+    warn "could not install $SYSTEM_CLI; the user CLI is still installed at $BIN_DIR/mso"
+  fi
+else
+  info "$SYSTEM_BIN_DIR is not on the invoking PATH — skipped the extra launcher"
+fi
+
+# Validate the actual launcher independently of PATH. The child installer may use
+# its own exported PATH for onboarding, but that is NOT treated as proof that the
+# parent shell can see the command.
+"$BIN_DIR/mso" -h >/dev/null 2>&1 || die "CLI launcher is not executable: $BIN_DIR/mso"
+export PATH="$BIN_DIR:$PATH"
+if [ "$CLI_IMMEDIATE" -eq 1 ]; then
+  ok "mso -h will resolve immediately after the installer returns ($parent_cli)"
+else
+  warn "mso is installed, but this shell's existing PATH cannot see it yet"
+  warn "for this shell run: export PATH=\"$BIN_DIR:\$PATH\""
+  info "future shells will load the persisted ~/.local/bin PATH block"
+fi
+
 # ---- systemd unit ----
-if [ "$DO_SERVICE" -eq 1 ] && command -v systemctl >/dev/null 2>&1; then
+if [ "$DO_SERVICE" -eq 1 ] && systemd_ready; then
   # Start via npm (always on PATH, ships with node) to match the proven prod unit;
   # PORT/HOSTNAME are set as env too so `next start` binds correctly regardless.
   NPM_BIN="$(command -v npm)"
@@ -356,7 +478,7 @@ EOF
       # /api/health perfectly while serving stale chunks, which is exactly how
       # a failed update used to report "health OK".
       if [ -z "$prev_build" ] || [ "$now_build" != "$prev_build" ]; then
-        up=1; ok "health OK (build ${now_build:-unknown})"; break
+        up=1; SERVICE_READY=1; ok "health OK (build ${now_build:-unknown})"; break
       fi
     fi
     sleep 2
@@ -369,68 +491,14 @@ EOF
       warn "$SERVICE is not running — check: journalctl -u mso -e"
     fi
   fi
-else
-  [ "$DO_SERVICE" -eq 1 ] && warn "no systemctl here — skipping service. Run manually: PORT=$PORT bun run start"
-fi
-
-# ---- CLI on PATH ----
-# The web UI is one frontend; bin/mso reaches the same /api surface from a shell.
-BIN_DIR="${MSO_BIN_DIR:-$HOME/.local/bin}"
-mkdir -p "$BIN_DIR"
-ln -sfn "$DIR/bin/mso" "$BIN_DIR/mso"
-ok "cli → $BIN_DIR/mso"
-
-# Make the command available to the PARENT shell immediately after curl|bash returns.
-# A child installer cannot export PATH back into its parent. /usr/local/bin is already
-# on the normal system PATH, so install a second launcher there when the name is free
-# (or already ours). Never overwrite an unrelated system command.
-if [ "$DO_SERVICE" -eq 1 ]; then
-  SYSTEM_CLI=/usr/local/bin/mso
-  if [ ! -e "$SYSTEM_CLI" ] && [ ! -L "$SYSTEM_CLI" ]; then
-    sudo_do ln -s "$DIR/bin/mso" "$SYSTEM_CLI"
-    ok "system cli → $SYSTEM_CLI"
-  elif [ -L "$SYSTEM_CLI" ]; then
-    current_cli="$(readlink "$SYSTEM_CLI")"
-    case "$current_cli" in
-      "$DIR/"*) sudo_do ln -sfn "$DIR/bin/mso" "$SYSTEM_CLI"; ok "system cli → $SYSTEM_CLI" ;;
-      *) warn "$SYSTEM_CLI already points elsewhere ($current_cli) — left untouched" ;;
-    esac
+elif [ "$DO_SERVICE" -eq 1 ]; then
+  if is_wsl; then
+    warn "WSL detected without systemd as PID 1 — service install skipped; the mso CLI is still installed"
+    info "for the full service: enable systemd in /etc/wsl.conf, run 'wsl --shutdown' from Windows, reopen WSL, then re-run this installer --onboard"
   else
-    warn "$SYSTEM_CLI already exists and is not a symlink — left untouched"
+    warn "systemd is not available as PID 1 — service install skipped; run manually: PORT=$PORT bun run start"
   fi
-else
-  info "--no-service: skipped /usr/local/bin launcher (user CLI still at $BIN_DIR/mso)"
 fi
-
-# A fresh distro often omits ~/.local/bin from PATH. Persist one small idempotent
-# block for future shells, and export it now so onboarding can invoke `mso`.
-path_block() {
-  local rc="$1"
-  [ -e "$rc" ] || : > "$rc"
-  grep -q '^# >>> mso cli >>>$' "$rc" 2>/dev/null && return
-  cat >> "$rc" <<'EOF'
-
-# >>> mso cli >>>
-case ":$PATH:" in
-  *":$HOME/.local/bin:"*) ;;
-  *) export PATH="$HOME/.local/bin:$PATH" ;;
-esac
-# <<< mso cli <<<
-EOF
-  info "added ~/.local/bin to PATH in $rc"
-}
-if [ "$BIN_DIR" = "$HOME/.local/bin" ]; then
-  path_block "$HOME/.profile"
-  case "${SHELL:-}" in
-    */bash) path_block "$HOME/.bashrc" ;;
-    */zsh)  path_block "$HOME/.zshrc" ;;
-  esac
-else
-  warn "custom MSO_BIN_DIR=$BIN_DIR is not written into shell profiles; add it to PATH yourself"
-fi
-export PATH="$BIN_DIR:$PATH"
-command -v mso >/dev/null 2>&1 || die "CLI symlink exists but is not executable: $BIN_DIR/mso"
-ok "mso command ready ($(command -v mso))"
 
 # ---- optional Claude Code integration ----
 # MSO catalogs $DIR/claude-skills directly, so these symlinks are NOT required by MSO.
@@ -480,13 +548,43 @@ case "$BIND" in
              session cookie is Secure. Put TLS in front, or tunnel to loopback.)" ;;
 esac
 
+if [ "$SERVICE_READY" -eq 1 ]; then
+  OPEN_STATUS="$REACH"
+  LOG_STATUS="journalctl -u mso -f"
+elif [ "$DO_SERVICE" -eq 0 ]; then
+  OPEN_STATUS="not running (--no-service). Start manually: cd $DIR && PORT=$PORT bun run start"
+  LOG_STATUS="no system service installed"
+elif is_wsl; then
+  OPEN_STATUS="not running (WSL systemd is unavailable). Enable systemd or start manually from $DIR"
+  LOG_STATUS="no system service installed"
+else
+  OPEN_STATUS="service did not pass health verification; inspect the service journal before opening the UI"
+  LOG_STATUS="journalctl -u mso -e"
+fi
+
 ok "mso installed at $DIR"
 cat <<EOF
 
-  Open:     $REACH
+  Runtime:  $OPEN_STATUS
   Env:      $DIR/.env.local
 EOF
-[ -n "$GEN_PW" ] && printf '  Password: %s   (shown once — save it now; edit OS_LOGIN_PASSWORD in .env.local + restart to change)\n' "$GEN_PW"
+[ -n "$GEN_PW" ] && printf '  Password: %s   (shown once — save it now; edit OS_LOGIN_PASSWORD in .env.local + service refresh to change)\n' "$GEN_PW"
+cat <<EOF
+
+  Pair your first device after the API is running (device approval is a browser allowlist, not standards-based 2FA):
+    1. Open the URL, enter the password — the browser lands PENDING and shows a device id.
+    2. On this server:
+         node $DIR/scripts/approve-device.js --list                 # see the pending id
+         node $DIR/scripts/approve-device.js <deviceId> "my phone"  # approve it
+    3. Reload + log in. Approve later devices from Settings → Devices.
+
+  Logs:     $LOG_STATUS
+  Update:   re-run this installer (pull + verify + build + service refresh), or --uninstall to remove
+  Listen:   $BIND:$PORT   (change with --bind / MSO_BIND)
+  Security: verify from OUTSIDE the box — `curl -m5 http://<public-ip>:$PORT/api/health`
+            run on your laptop is the only test that proves what is reachable.
+            Review ~/.mso/audit.log.
+EOF
 
 # A successful fresh install should lead directly into a usable product. curl|bash
 # owns stdin, so interactive setup uses the controlling terminal explicitly.
@@ -496,7 +594,7 @@ case "$ONBOARD_MODE" in
   never) RUN_ONBOARD=0 ;;
   auto) [ "$FRESH_INSTALL" -eq 1 ] && RUN_ONBOARD=1 ;;
 esac
-if [ "$RUN_ONBOARD" -eq 1 ] && [ "$DO_SERVICE" -eq 1 ]; then
+if [ "$RUN_ONBOARD" -eq 1 ] && [ "$SERVICE_READY" -eq 1 ]; then
   if [ "$YES" -eq 1 ]; then
     echo
     info "running minimal non-interactive onboarding (-y)…"
@@ -512,21 +610,5 @@ if [ "$RUN_ONBOARD" -eq 1 ] && [ "$DO_SERVICE" -eq 1 ]; then
     warn "no interactive terminal detected — onboarding skipped. Run: mso onboard"
   fi
 elif [ "$RUN_ONBOARD" -eq 1 ]; then
-  warn "--no-service leaves no running API to configure — run 'mso onboard' after starting MSO"
+  warn "no verified running MSO API is available for onboarding — start/enable the service, then run 'mso onboard'"
 fi
-cat <<EOF
-
-  Pair your first device (device approval is a browser allowlist, not standards-based 2FA):
-    1. Open the URL, enter the password — the browser lands PENDING and shows a device id.
-    2. On this server:
-         node $DIR/scripts/approve-device.js --list                 # see the pending id
-         node $DIR/scripts/approve-device.js <deviceId> "my phone"  # approve it
-    3. Reload + log in. Approve later devices from Settings → Devices.
-
-  Logs:     journalctl -u mso -f
-  Update:   re-run this installer (pull + rebuild + restart), or --uninstall to remove
-  Listen:   $BIND:$PORT   (change with --bind / MSO_BIND)
-  Security: verify from OUTSIDE the box — \`curl -m5 http://<public-ip>:$PORT/api/health\`
-            run on your laptop is the only test that proves what is reachable.
-            Review ~/.mso/audit.log.
-EOF


### PR DESCRIPTION
## What changed
- install the `mso` CLI before attempting systemd service setup
- require systemd to actually be PID 1 instead of treating a `systemctl` binary as proof
- verify CLI discoverability against the invoking shell PATH and persist a safe `~/.local/bin` fallback
- make WSL/no-service runtime messaging truthful
- document WSL2 behavior in README + install guide
- add `fast-check` property-based fuzz tests for path containment, provider SSRF boundaries, and PKCE

## Verification
- full local pre-push gate passed: typecheck, lint, 1754 tests, docs/changelog/cycles/audit, production build
- isolated clean-HOME/PATH install with `--no-service` completed successfully
- parent shell resolved `mso` immediately after installer return and `mso -h` succeeded
- property fuzzing uses `fast-check`, which OpenSSF Scorecard recognizes for TypeScript fuzzing

No Scorecard governance alert is dismissed by this PR.